### PR TITLE
处理visual studio编译时，由于max min冲突导致的函数未定义的问题

### DIFF
--- a/src/TestTrader/TestTrader.vcxproj
+++ b/src/TestTrader/TestTrader.vcxproj
@@ -111,7 +111,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/WtBtCore/WtBtCore.vcxproj
+++ b/src/WtBtCore/WtBtCore.vcxproj
@@ -131,7 +131,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/WtBtPorter/WtBtPorter.vcxproj
+++ b/src/WtBtPorter/WtBtPorter.vcxproj
@@ -126,7 +126,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;_EXPORT_WTBTPORTER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;_EXPORT_WTBTPORTER;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/WtBtRunner/WtBtRunner.vcxproj
+++ b/src/WtBtRunner/WtBtRunner.vcxproj
@@ -120,7 +120,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/WtCore/WtCore.vcxproj
+++ b/src/WtCore/WtCore.vcxproj
@@ -163,7 +163,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -176,7 +176,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/WtDataStorage/WtDataStorage.vcxproj
+++ b/src/WtDataStorage/WtDataStorage.vcxproj
@@ -107,7 +107,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/WtDataStorage/WtDataWriter.h
+++ b/src/WtDataStorage/WtDataWriter.h
@@ -7,6 +7,7 @@
 #include "../Share/BoostMappingFile.hpp"
 
 #include <queue>
+#include <map>
 
 typedef std::shared_ptr<BoostMappingFile> BoostMFPtr;
 

--- a/src/WtDataStorageAD/WtDataStorageAD.vcxproj
+++ b/src/WtDataStorageAD/WtDataStorageAD.vcxproj
@@ -107,7 +107,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/WtDtCore/WtDtCore.vcxproj
+++ b/src/WtDtCore/WtDtCore.vcxproj
@@ -125,7 +125,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/WtDtPorter/WtDtPorter.vcxproj
+++ b/src/WtDtPorter/WtDtPorter.vcxproj
@@ -105,7 +105,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -124,7 +124,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/WtDtServo/WtDtServo.vcxproj
+++ b/src/WtDtServo/WtDtServo.vcxproj
@@ -125,7 +125,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/WtExecMon/WtExecMon.vcxproj
+++ b/src/WtExecMon/WtExecMon.vcxproj
@@ -128,7 +128,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>

--- a/src/WtPorter/WtPorter.vcxproj
+++ b/src/WtPorter/WtPorter.vcxproj
@@ -124,7 +124,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/src/WtRunner/WtRunner.vcxproj
+++ b/src/WtRunner/WtRunner.vcxproj
@@ -114,7 +114,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/src/WtUftCore/TraderAdapter.cpp
+++ b/src/WtUftCore/TraderAdapter.cpp
@@ -27,6 +27,7 @@
 #include "../Share/DLLHelper.hpp"
 
 #include <exception>
+#include <algorithm>
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
 
@@ -794,7 +795,7 @@ void TraderAdapter::onPushOrder(WTSOrderInfo* orderInfo)
 				{
 					if (isToday)
 					{
-						pItem.l_newavail -= min(pItem.l_newavail, qty);	//如果是平今, 则只需要更新可平今仓
+						pItem.l_newavail -= std::min(pItem.l_newavail, qty);	//如果是平今, 则只需要更新可平今仓
 					}
 					else
 					{
@@ -802,30 +803,30 @@ void TraderAdapter::onPushOrder(WTSOrderInfo* orderInfo)
 
 						//如果是平仓, 则先更新可平昨仓, 还有剩余, 再更新可平今仓
 						//如果品种区分平昨平今, 也按照这个流程, 因为平昨的总数量不可能超出昨仓
-						double maxQty = min(pItem.l_preavail, qty);
+						double maxQty = std::min(pItem.l_preavail, qty);
 						pItem.l_preavail -= maxQty;
 						left -= maxQty;
 
 						if (left > 0)
-							pItem.l_newavail -= min(pItem.l_newavail, left);
+							pItem.l_newavail -= std::min(pItem.l_newavail, left);
 					}
 				}
 				else //平空
 				{
 					if (isToday)
 					{
-						pItem.s_newavail -= min(pItem.s_newavail, qty);
+						pItem.s_newavail -= std::min(pItem.s_newavail, qty);
 					}
 					else
 					{
 						double left = qty;
 
-						double maxQty = min(pItem.s_preavail, qty);
+						double maxQty = std::min(pItem.s_preavail, qty);
 						pItem.s_preavail -= maxQty;
 						left -= maxQty;
 
 						if (left > 0)
-							pItem.s_newavail -= min(pItem.s_newavail, left);
+							pItem.s_newavail -= std::min(pItem.s_newavail, left);
 					}
 				}
 				printPosition(stdCode.c_str(), pItem);
@@ -966,7 +967,7 @@ void TraderAdapter::onPushTrade(WTSTradeInfo* tradeRecord)
 		else
 		{
 			double left = vol;
-			double maxVol = min(left, pItem.l_prevol);
+			double maxVol = std::min(left, pItem.l_prevol);
 			pItem.l_prevol -= maxVol;
 			left -= maxVol;
 			pItem.l_newvol -= left;
@@ -987,7 +988,7 @@ void TraderAdapter::onPushTrade(WTSTradeInfo* tradeRecord)
 		else
 		{
 			double left = vol;
-			double maxVol = min(left, pItem.s_prevol);
+			double maxVol = std::min(left, pItem.s_prevol);
 			pItem.s_prevol -= maxVol;
 			left -= maxVol;
 			pItem.s_newvol -= left;

--- a/src/WtUftCore/TraderAdapter.h
+++ b/src/WtUftCore/TraderAdapter.h
@@ -14,6 +14,7 @@
 #include "../Share/BoostFile.hpp"
 #include "../Share/StdUtils.hpp"
 #include "../Includes/WTSCollection.hpp"
+#include <algorithm>
 
 NS_WTP_BEGIN
 class WTSVariant;

--- a/src/WtUftCore/WtHftCore.vcxproj
+++ b/src/WtUftCore/WtHftCore.vcxproj
@@ -124,7 +124,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,7 +137,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
使用visual stuidio进行编译的时候，好像由于<windows.h>中min和max冲突，无法正常使用，需要在对应的项目中加入宏NOMINMAX
加入宏后会导致min，max无法使用，需要#include <algorithm>后，将所有min，max前加上命名空间std::
本次pr主要处理了两个部分
1 增加预编译宏 NOMINMAX
2 添加#include <algorithm>
3 在min max前添加std::命名空间