### PR TITLE
[mod] 增加更丰富的目标接口

### DIFF
--- a/src/Includes/ExecuteDefs.h
+++ b/src/Includes/ExecuteDefs.h
@@ -134,6 +134,11 @@ public:
 	virtual uint64_t	getCurTime() = 0;
 
 	/*
+	 *  计算市值
+	 */
+	virtual bool		getMarketValue(double& market_value) { return false; };
+
+	/*
 	 *	注册定时器
 	 *	@stdCode	合约代码
 	 *	@elapse		时间间隔,单位毫秒
@@ -176,20 +181,6 @@ public:
 	 *	newVol	新的目标仓位
 	 */
 	virtual void set_position(const char* stdCode, double newVol) = 0;
-
-	/*
-	 *	设置新的目标金额
-	 *	stdCode	合约代码
-	 *	newVol	新的目标金额
-	 */
-	virtual void set_amount(const char* stdCode, double newAmount) {};
-
-	/*
-	 *	设置新的目标持仓比例
-	 *	stdCode	合约代码
-	 *	newVol	新的目标比例
-	 */
-	virtual void set_ratio(const char* stdCode, double newRatio) {};
 
 	/*
 	 *	清理全部持仓，锁仓的情况下也要清理

--- a/src/Includes/ExecuteDefs.h
+++ b/src/Includes/ExecuteDefs.h
@@ -178,6 +178,20 @@ public:
 	virtual void set_position(const char* stdCode, double newVol) = 0;
 
 	/*
+	 *	设置新的目标金额
+	 *	stdCode	合约代码
+	 *	newVol	新的目标金额
+	 */
+	virtual void set_amount(const char* stdCode, double newAmount) {};
+
+	/*
+	 *	设置新的目标持仓比例
+	 *	stdCode	合约代码
+	 *	newVol	新的目标比例
+	 */
+	virtual void set_ratio(const char* stdCode, double newRatio) {};
+
+	/*
 	 *	清理全部持仓，锁仓的情况下也要清理
 	 *	stdCode	合约代码	
 	 */

--- a/src/WtCore/IExecCommand.h
+++ b/src/WtCore/IExecCommand.h
@@ -33,6 +33,16 @@ public:
 	virtual void on_position_changed(const char* stdCode, double targetPos) {}
 
 	/*
+ *	合约金额变动
+ */
+	virtual void on_amount_changed(const char* stdCode, double targetAmount) {}
+
+	/*
+	 *	合约比例变动
+	 */
+	virtual void on_ratio_changed(const char* stdCode, double targetRatio) {}
+
+	/*
 	 *	实时行情回调
 	 */
 	virtual void on_tick(const char* stdCode, WTSTickData* newTick) {}

--- a/src/WtCore/WtDiffExecuter.h
+++ b/src/WtCore/WtDiffExecuter.h
@@ -83,6 +83,16 @@ public:
 	virtual void on_position_changed(const char* stdCode, double targetPos) override;
 
 	/*
+	 *	合约金额变动
+	 */
+	virtual void on_amount_changed(const char* stdCode, double targetAmount) override;
+
+	/*
+	 *	合约比例变动
+	 */
+	virtual void on_ratio_changed(const char* stdCode, double targetRatio) override;
+
+	/*
 	 *	实时行情回调
 	 */
 	virtual void on_tick(const char* stdCode, WTSTickData* newTick) override;
@@ -138,6 +148,10 @@ private:
 
 	faster_hashmap<LongKey, double> _target_pos;
 	faster_hashmap<LongKey, double> _diff_pos;
+	faster_hashmap<LongKey, double> _target_amount;
+	faster_hashmap<LongKey, double> _diff_amount;
+	faster_hashmap<LongKey, double> _target_ratio;
+	faster_hashmap<LongKey, double> _diff_ratio;
 
 	typedef std::shared_ptr<boost::threadpool::pool> ThreadPoolPtr;
 	ThreadPoolPtr		_pool;

--- a/src/WtCore/WtDiffExecuter.h
+++ b/src/WtCore/WtDiffExecuter.h
@@ -71,6 +71,14 @@ public:
 	virtual uint64_t	getCurTime() override;
 
 public:
+	virtual bool			getMarketValue(double& market_value) override;
+
+private:
+	bool amountToPos(const char* stdCode, double amount, double& pos);
+	bool ratioToPos(const char* stdCode, double ratio, double& pos);
+	inline void checkTarget();
+
+public:
 	/*
 	 *	设置目标仓位
 	 */
@@ -152,6 +160,7 @@ private:
 	faster_hashmap<LongKey, double> _diff_amount;
 	faster_hashmap<LongKey, double> _target_ratio;
 	faster_hashmap<LongKey, double> _diff_ratio;
+	double							_avaliable;
 
 	typedef std::shared_ptr<boost::threadpool::pool> ThreadPoolPtr;
 	ThreadPoolPtr		_pool;

--- a/src/WtCore/WtExecMgr.h
+++ b/src/WtCore/WtExecMgr.h
@@ -23,6 +23,8 @@ public:
 
 	void	set_positions(faster_hashmap<LongKey, double> target_pos);
 	void	handle_pos_change(const char* stdCode, double targetPos, const char* execid = "ALL");
+	void	handle_amount_change(const char* stdCode, double targetAmount, const char* execid = "ALL");
+	void	handle_ratio_change(const char* stdCode, double targetRatio, const char* execid = "ALL");
 	void	handle_tick(const char* stdCode, WTSTickData* curTick);
 
 	/*

--- a/src/WtCore/WtLocalExecuter.cpp
+++ b/src/WtCore/WtLocalExecuter.cpp
@@ -278,6 +278,52 @@ void WtLocalExecuter::on_position_changed(const char* stdCode, double targetPos)
 	unit->self()->set_position(stdCode, targetPos);
 }
 
+void WtLocalExecuter::on_amount_changed(const char* stdCode, double targetAmount)
+{
+	ExecuteUnitPtr unit = getUnit(stdCode);
+	if (unit == NULL)
+		return;
+
+	double oldAmount = _target_amount[stdCode];
+	_target_amount[stdCode] = targetAmount;
+
+	if (!decimal::eq(oldAmount, targetAmount))
+	{
+		WTSLogger::log_dyn("executer", _name.c_str(), LL_INFO, "Target amount of {} changed: {} -> {}", stdCode, oldAmount, targetAmount);
+	}
+
+	if (_trader && !_trader->checkOrderLimits(stdCode))
+	{
+		WTSLogger::log_dyn("executer order on", _name.c_str(), LL_INFO, "{} is disabled", stdCode);
+		return;
+	}
+
+	unit->self()->set_amount(stdCode, targetAmount);
+}
+
+void WtLocalExecuter::on_ratio_changed(const char* stdCode, double targetRatio)
+{
+	ExecuteUnitPtr unit = getUnit(stdCode);
+	if (unit == NULL)
+		return;
+
+	double oldRatio = _target_ratio[stdCode];
+	_target_ratio[stdCode] = targetRatio;
+
+	if (!decimal::eq(oldRatio, targetRatio))
+	{
+		WTSLogger::log_dyn("executer", _name.c_str(), LL_INFO, "Target ratio of {} changed: {} -> {}", stdCode, oldRatio, targetRatio);
+	}
+
+	if (_trader && !_trader->checkOrderLimits(stdCode))
+	{
+		WTSLogger::log_dyn("executer order on", _name.c_str(), LL_INFO, "{} is disabled", stdCode);
+		return;
+	}
+
+	unit->self()->set_ratio(stdCode, targetRatio);
+}
+
 void WtLocalExecuter::set_position(const faster_hashmap<LongKey, double>& targets)
 {
 	/*

--- a/src/WtCore/WtLocalExecuter.h
+++ b/src/WtCore/WtLocalExecuter.h
@@ -80,6 +80,16 @@ public:
 	virtual void on_position_changed(const char* stdCode, double targetPos) override;
 
 	/*
+	 *	合约金额变动
+	 */
+	virtual void on_amount_changed(const char* stdCode, double targetAmount) override;
+
+	/*
+	 *	合约比例变动
+	 */
+	virtual void on_ratio_changed(const char* stdCode, double targetRatio) override;
+
+	/*
 	 *	实时行情回调
 	 */
 	virtual void on_tick(const char* stdCode, WTSTickData* newTick) override;
@@ -150,6 +160,8 @@ private:
 	faster_hashset<LongKey> _channel_holds;		//通道持仓
 
 	faster_hashmap<LongKey, double> _target_pos;
+	faster_hashmap<LongKey, double> _target_amount;
+	faster_hashmap<LongKey, double> _target_ratio;
 
 	typedef std::shared_ptr<boost::threadpool::pool> ThreadPoolPtr;
 	ThreadPoolPtr		_pool;

--- a/src/WtCore/WtLocalExecuter.h
+++ b/src/WtCore/WtLocalExecuter.h
@@ -68,6 +68,14 @@ public:
 	virtual uint64_t	getCurTime() override;
 
 public:
+	virtual bool			getMarketValue(double& market_value) override;
+
+private:
+	bool amountToPos(const char* stdCode, double amount, double& pos);
+	bool ratioToPos(const char* stdCode, double ratio, double& pos);
+	inline void checkTarget();
+
+public:
 	/*
 	 *	设置目标仓位
 	 */
@@ -127,7 +135,7 @@ public:
 	/*
 	 *	资金回报
 	 */
-	virtual void on_account(const char* currency, double prebalance, double balance, double dynbalance, 
+	virtual void on_account(const char* currency, double prebalance, double balance, double dynbalance,
 		double avaliable, double closeprofit, double dynprofit, double margin, double fee, double deposit, double withdraw) override;
 
 private:
@@ -162,7 +170,7 @@ private:
 	faster_hashmap<LongKey, double> _target_pos;
 	faster_hashmap<LongKey, double> _target_amount;
 	faster_hashmap<LongKey, double> _target_ratio;
-
+	double							_avaliable;
 	typedef std::shared_ptr<boost::threadpool::pool> ThreadPoolPtr;
 	ThreadPoolPtr		_pool;
 };

--- a/src/WtExecMon/WtExecPorter.cpp
+++ b/src/WtExecMon/WtExecPorter.cpp
@@ -83,3 +83,13 @@ void set_position(WtString stdCode, double targetPos)
 {
 	getRunner().setPosition(stdCode, targetPos);
 }
+
+void set_amount(WtString stdCode, double targetAmount)
+{
+	getRunner().setAmount(stdCode, targetAmount);
+}
+
+void set_ratio(WtString stdCode, double targetRatio)
+{
+	getRunner().setRatio(stdCode, targetRatio);
+}

--- a/src/WtExecMon/WtExecPorter.h
+++ b/src/WtExecMon/WtExecPorter.h
@@ -23,6 +23,10 @@ extern "C"
 
 	EXPORT_FLAG	void		set_position(WtString stdCode, double targetPos);
 
+	EXPORT_FLAG	void		set_amount(WtString stdCode, double targetAmount);
+
+	EXPORT_FLAG	void		set_ratio(WtString stdCode, double targetRatio);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/WtExecMon/WtExecRunner.cpp
+++ b/src/WtExecMon/WtExecRunner.cpp
@@ -416,6 +416,16 @@ void WtExecRunner::setPosition(const char* stdCode, double targetPos)
 	_exe_mgr.handle_pos_change(stdCode, targetPos);
 }
 
+void WtExecRunner::setAmount(const char* stdCode, double tragetAmount)
+{
+	_exe_mgr.handle_amount_change(stdCode, tragetAmount);
+}
+
+void WtExecRunner::setRatio(const char* stdCode, double targetRatio)
+{
+	_exe_mgr.handle_ratio_change(stdCode, targetRatio);
+}
+
 bool WtExecRunner::initActionPolicy()
 {
 	const char* action_file = _config->getCString("bspolicy");

--- a/src/WtExecMon/WtExecRunner.h
+++ b/src/WtExecMon/WtExecRunner.h
@@ -34,6 +34,10 @@ public:
 
 	void setPosition(const char* stdCode, double targetPos);
 
+	void setAmount(const char* stdCode, double targetAmount);
+
+	void setRatio(const char* stdCode, double ratio);
+
 	bool addExeFactories(const char* folder);
 
 	IBaseDataMgr*	get_bd_mgr() { return &_bd_mgr; }


### PR DESCRIPTION
增加set_amount 和 set_ratio的执行器接口
在执行器层面，增加市值计算，用于配合on_account 计算账户资产。
接受set_amount和set_ratio后，会将其转换为set_pos,如果没有tick，则会在on_tick回调中检查

Todo：1 处理回测中，使用该接口的情况   2 处理期货中，不同保证金的计算