### PR TITLE
[mod] 处理无法可视化回测结果的问题。

### DIFF
--- a/src/WtBtRunner/WtBtRunner.cpp
+++ b/src/WtBtRunner/WtBtRunner.cpp
@@ -68,19 +68,22 @@ int main()
 	{
 		CtaMocker* mocker = new CtaMocker(&replayer, "cta", slippage);
 		mocker->init_cta_factory(cfg->get("cta"));
-		replayer.register_sink(mocker, "cta");
+		const char* stra_id = cfg->get("cta")->get("strategy")->getCString("id");
+		replayer.register_sink(mocker, stra_id);
 	}
 	else if (strcmp(mode, "hft") == 0)
 	{
 		HftMocker* mocker = new HftMocker(&replayer, "hft");
 		mocker->init_hft_factory(cfg->get("hft"));
-		replayer.register_sink(mocker, "hft");
+		const char* stra_id = cfg->get("hft")->get("strategy")->getCString("id");
+		replayer.register_sink(mocker, stra_id);
 	}
 	else if (strcmp(mode, "sel") == 0)
 	{
 		SelMocker* mocker = new SelMocker(&replayer, "sel", slippage);
-		mocker->init_sel_factory(cfg->get("cta"));
-		replayer.register_sink(mocker, "sel");
+		mocker->init_sel_factory(cfg->get("sel"));
+		const char* stra_id = cfg->get("sel")->get("strategy")->getCString("id");
+		replayer.register_sink(mocker, stra_id);
 	}
 	else if (strcmp(mode, "exec") == 0)
 	{
@@ -92,12 +95,13 @@ int main()
 	{
 		UftMocker* mocker = new UftMocker(&replayer, "uft");
 		mocker->init_uft_factory(cfg->get("uft"));
-		replayer.register_sink(mocker, "uft");
+		const char* stra_id = cfg->get("uft")->get("strategy")->getCString("id");
+		replayer.register_sink(mocker, stra_id);
 	}
 
 	replayer.prepare();
 
-	replayer.run();
+	replayer.run(true);
 
 	printf("press enter key to exit\r\n");
 	getchar();


### PR DESCRIPTION
[mod] 增加额外的配置，解决cpp回测结果中，output中缺少btenv文件导致无法可视化回测结果的问题。
1. 增加run中的参数，设置bNeedDumps为true
2. 将btenvs的输出目录，改为对应的策略id目录