### PR TITLE
[mod]历史数据读取闪崩

### DIFF
--- a/src/WtDataStorage/WtDataReader.cpp
+++ b/src/WtDataStorage/WtDataReader.cpp
@@ -1737,6 +1737,8 @@ WTSKlineSlice* WtDataReader::readKlineSlice(const char* stdCode, WTSKlinePeriod 
 		//历史数据，直接从缓存的历史数据尾部截取
 		BarsList& barList = _bars_cache[key];
 		hisCnt = min(hisCnt, (uint32_t)barList._bars.size());
+		if (hisCnt == 0)
+			return NULL;
 		hisHead = &barList._bars[barList._bars.size() - hisCnt];//indexBarFromCache(key, etime, hisCnt, period == KP_DAY);
 	}
 


### PR DESCRIPTION
理论上bHasHisData为true是不会发生这个的，但有时还是进来了，导致出现了错误
出现的场景，datakit第一次启动时，立刻启动策略，通常会闪崩