### PR TITLE
[mod] 修复增量回测中无法读取json文件的问题

### DIFF
--- a/src/WtBtCore/CtaMocker.cpp
+++ b/src/WtBtCore/CtaMocker.cpp
@@ -449,9 +449,10 @@ bool CtaMocker::init_cta_factory(WTSVariant* cfg)
 
 void CtaMocker::load_incremental_data(const char* incremental_backtest_base)
 {
-	WTSLogger::info("loading incremental data from: {}", incremental_backtest_base);
-	std::string folder = incremental_backtest_base;
+	std::string folder = WtHelper::getOutputDir();
+	folder += incremental_backtest_base;
 	folder += "/";
+	WTSLogger::info("loading incremental data from: {}", folder);
 
 	std::string tradesFilename = folder + "trades.csv";
 	if (boost::filesystem::exists(tradesFilename))
@@ -521,6 +522,7 @@ void CtaMocker::load_incremental_data(const char* incremental_backtest_base)
 	std::string strategyDumpFilename = folder + fmtutil::format("{}.json", incremental_backtest_base);
 	if (boost::filesystem::exists(strategyDumpFilename))
 	{
+		WTSLogger::info("load incremental data json: {}", strategyDumpFilename);
 		FILE* fp = fopen(strategyDumpFilename.c_str(), "rb");
 		char readBuffer[65536];
 		rj::FileReadStream strategyDumpFile(fp, readBuffer, sizeof(readBuffer));
@@ -608,6 +610,10 @@ void CtaMocker::load_incremental_data(const char* incremental_backtest_base)
 				}
 			}
 		}
+	}
+	else
+	{
+		WTSLogger::warn("fail load incremental data json: {}", strategyDumpFilename);
 	}
 }
 


### PR DESCRIPTION
修复增量回测中，无法读取json文件的问题，限制只能读取output下面指定的策略名，并读取同名的json文件
现在指定基础的增量回测文件，必须在output下，且文件名和下面的json必须同名，否则读不到