### PR TITLE
[mod] 在策略更改理论持仓以及组合读取策略理论持仓时加个锁

### DIFF
--- a/src/WtCore/CtaStraBaseCtx.h
+++ b/src/WtCore/CtaStraBaseCtx.h
@@ -14,6 +14,7 @@
 
 #include "../Share/BoostFile.hpp"
 #include "../Share/fmtlib.h"
+#include "../Share/SpinMutex.hpp"
 
 #include <unordered_map>
 
@@ -361,6 +362,9 @@ protected:
 	} ChartIndex;
 
 	faster_hashmap<LongKey, ChartIndex>	_chart_indice;
+
+private:
+	SpinMutex		_mutex;
 };
 
 


### PR DESCRIPTION
[mod] 在策略更改理论持仓，以及组合读取策略理论持仓时，要加个锁，避免出现组合轧差同步与信号同时触发，导致的反复发单和信号覆盖