### PR TITLE
fix compiling issue on ubuntu 20.04

### DIFF
--- a/src/WTSUtils/StackTracer/StackTracer.cpp
+++ b/src/WTSUtils/StackTracer/StackTracer.cpp
@@ -1,5 +1,6 @@
 
 #include "StackTracer.h"
+#include "cstdlib"
 
 #ifdef _WIN32
 #	ifdef _MSC_VER


### PR DESCRIPTION
The compiling breaks on ubuntu 20.04 with cmake 3.22.1 and GCC 12.2.0-19.

```
[  0%] Building CXX object WTSUtils/CMakeFiles/WTSUtils.dir/StackTracer/StackTracer.cpp.o
/home/rnd/Projects/wondertrader/src/WTSUtils/StackTracer/StackTracer.cpp: In function 'void print_stack_trace(TracerLogCallback)':
/home/rnd/Projects/wondertrader/src/WTSUtils/StackTracer/StackTracer.cpp:82:9: error: 'free' was not declared in this scope
   82 |         free(symbollist);
      |         ^~~~
/home/rnd/Projects/wondertrader/src/WTSUtils/StackTracer/StackTracer.cpp:24:1: note: 'free' is defined in header '<cstdlib>'; did you forget to '#include <cstdlib>'?
   23 | #include <cxxabi.h>
  +++ |+#include <cstdlib>
   24 | void print_stack_trace(TracerLogCallback cb) {
make[2]: *** [WTSUtils/CMakeFiles/WTSUtils.dir/build.make:958: WTSUtils/CMakeFiles/WTSUtils.dir/StackTracer/StackTracer.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:980: WTSUtils/CMakeFiles/WTSUtils.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```