### PR TITLE
[mod]在WTSCmpHelper中用size_t而不是uint32_t来表示数据长度，使得64位系统可以处理更大的数据量而不会溢出

### DIFF
--- a/src/WTSUtils/WTSCmpHelper.hpp
+++ b/src/WTSUtils/WTSCmpHelper.hpp
@@ -16,7 +16,7 @@
 class WTSCmpHelper
 {
 public:
-	static std::string compress_data(const void* data, uint32_t dataLen, uint32_t uLevel = 1)
+	static std::string compress_data(const void* data, size_t dataLen, uint32_t uLevel = 1)
 	{
 		std::string desBuf;
 		std::size_t const desLen = ZSTD_compressBound(dataLen);
@@ -26,7 +26,7 @@ public:
 		return desBuf;
 	}
 
-	static std::string uncompress_data(const void* data, uint32_t dataLen)
+	static std::string uncompress_data(const void* data, size_t dataLen)
 	{
 		std::string desBuf;
 		unsigned long long const desLen = ZSTD_getFrameContentSize(data, dataLen);

--- a/src/WtBtCore/HisDataReplayer.cpp
+++ b/src/WtBtCore/HisDataReplayer.cpp
@@ -70,7 +70,7 @@ bool proc_block_data(const char* tag, std::string& content, bool isBar, bool bKe
 		}
 
 		//将文件头后面的数据进行解压
-		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, (uint32_t)blkV2->_size);
+		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, blkV2->_size);
 	}
 	else
 	{
@@ -3594,7 +3594,7 @@ bool HisDataReplayer::cacheFinalBarsFromLoader(const std::string& key, const cha
 		else
 		{
 			HisKlineBlockV2* kBlock = (HisKlineBlockV2*)content.c_str();
-			std::string rawData = WTSCmpHelper::uncompress_data(kBlock->_data, (uint32_t)kBlock->_size);
+			std::string rawData = WTSCmpHelper::uncompress_data(kBlock->_data, kBlock->_size);
 			uint32_t barcnt = rawData.size() / sizeof(WTSBarStruct);
 
 			if (bSubbed)

--- a/src/WtDataStorage/WtDataReader.cpp
+++ b/src/WtDataStorage/WtDataReader.cpp
@@ -73,7 +73,7 @@ bool proc_block_data(std::string& content, bool isBar, bool bKeepHead /* = true 
 		}
 
 		//将文件头后面的数据进行解压
-		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, (uint32_t)blkV2->_size);
+		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, blkV2->_size);
 	}
 	else
 	{
@@ -519,7 +519,7 @@ WTSOrdQueSlice* WtDataReader::readOrdQueSlice(const char* stdCode, uint32_t coun
 			}
 
 			//需要解压
-			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, (uint32_t)tBlockV2->_size);
+			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, tBlockV2->_size);
 
 			//将原来的buffer只保留一个头部,并将所有tick数据追加到尾部
 			hisBlkPair._buffer.resize(sizeof(HisOrdQueBlock));
@@ -662,7 +662,7 @@ WTSOrdDtlSlice* WtDataReader::readOrdDtlSlice(const char* stdCode, uint32_t coun
 			}
 
 			//需要解压
-			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, (uint32_t)tBlockV2->_size);
+			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, tBlockV2->_size);
 
 			//将原来的buffer只保留一个头部,并将所有tick数据追加到尾部
 			hisBlkPair._buffer.resize(sizeof(HisOrdDtlBlock));
@@ -805,7 +805,7 @@ WTSTransSlice* WtDataReader::readTransSlice(const char* stdCode, uint32_t count,
 			}
 
 			//需要解压
-			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, (uint32_t)tBlockV2->_size);
+			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, tBlockV2->_size);
 
 			//将原来的buffer只保留一个头部,并将所有tick数据追加到尾部
 			hisBlkPair._buffer.resize(sizeof(HisTransBlock));

--- a/src/WtDataStorage/WtDataWriter.cpp
+++ b/src/WtDataStorage/WtDataWriter.cpp
@@ -1773,7 +1773,7 @@ bool WtDataWriter::proc_block_data(const char* tag, std::string& content, bool i
 		}
 
 		//将文件头后面的数据进行解压
-		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, (uint32_t)blkV2->_size);
+		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, blkV2->_size);
 	}
 	else
 	{

--- a/src/WtDataStorage/WtRdmDtReader.cpp
+++ b/src/WtDataStorage/WtRdmDtReader.cpp
@@ -719,7 +719,7 @@ WTSOrdQueSlice* WtRdmDtReader::readOrdQueSliceByRange(const char* stdCode, uint6
 			}
 
 			//需要解压
-			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, (uint32_t)tBlockV2->_size);
+			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, tBlockV2->_size);
 
 			//将原来的buffer只保留一个头部,并将所有tick数据追加到尾部
 			hisBlkPair._buffer.resize(sizeof(HisOrdQueBlock));
@@ -894,7 +894,7 @@ WTSOrdDtlSlice* WtRdmDtReader::readOrdDtlSliceByRange(const char* stdCode, uint6
 			}
 
 			//需要解压
-			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, (uint32_t)tBlockV2->_size);
+			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, tBlockV2->_size);
 
 			//将原来的buffer只保留一个头部,并将所有tick数据追加到尾部
 			hisBlkPair._buffer.resize(sizeof(HisOrdDtlBlock));
@@ -1068,7 +1068,7 @@ WTSTransSlice* WtRdmDtReader::readTransSliceByRange(const char* stdCode, uint64_
 			}
 
 			//需要解压
-			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, (uint32_t)tBlockV2->_size);
+			std::string buf = WTSCmpHelper::uncompress_data(tBlockV2->_data, tBlockV2->_size);
 
 			//将原来的buffer只保留一个头部,并将所有tick数据追加到尾部
 			hisBlkPair._buffer.resize(sizeof(HisTransBlock));
@@ -1390,7 +1390,7 @@ bool WtRdmDtReader::cacheHisBarsFromFile(void* codeInfo, const std::string& key,
 				if (kBlockV2->_size == 0)
 					break;
 
-				buffer = WTSCmpHelper::uncompress_data(kBlockV2->_data, (uint32_t)kBlockV2->_size);
+				buffer = WTSCmpHelper::uncompress_data(kBlockV2->_data, kBlockV2->_size);
 			}
 			else
 			{

--- a/src/WtDtHelper/WtDtHelper.cpp
+++ b/src/WtDtHelper/WtDtHelper.cpp
@@ -55,7 +55,7 @@ bool proc_block_data(std::string& content, bool isBar, bool bKeepHead /* = true 
 		}
 
 		//将文件头后面的数据进行解压
-		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, (uint32_t)blkV2->_size);
+		buffer = WTSCmpHelper::uncompress_data(content.data() + BLOCK_HEADERV2_SIZE, blkV2->_size);
 	}
 	else
 	{
@@ -449,7 +449,7 @@ void trans_csv_bars(WtString csvFolder, WtString binFolder, WtString period, Fun
 		kBlock._type = btype;
 		kBlock._version = BLOCK_VERSION_CMP_V2;
 
-		std::string cmprsData = WTSCmpHelper::compress_data(bars.data(), (uint32_t)(sizeof(WTSBarStruct)*bars.size()));
+		std::string cmprsData = WTSCmpHelper::compress_data(bars.data(), sizeof(WTSBarStruct)*bars.size());
 		kBlock._size = cmprsData.size();
 
 		std::string filename = StrUtil::standardisePath(binFolder);


### PR DESCRIPTION
某些市场的热门品种一天的ticks数据量可能超过uint32_t的表示范围，导致压缩和解压数据时发生溢出