### PR TITLE
[fix] ParserUDP::subscribe()

### DIFF
--- a/src/ParserUDP/ParserUDP.cpp
+++ b/src/ParserUDP/ParserUDP.cpp
@@ -192,12 +192,12 @@ void ParserUDP::subscribe()
 		{
 			StdUniqueLock lock(_mtx_queue);
 			_send_queue.push(data);
-		}
 
-		data.resize(sizeof(UDPReqPacket), 0);
-		req = (UDPReqPacket*)data.data();
-		req->_type = UDP_MSG_SUBSCRIBE;
-		length = 0;
+			data.resize(sizeof(UDPReqPacket), 0);
+			req = (UDPReqPacket*)data.data();
+			req->_type = UDP_MSG_SUBSCRIBE;
+			length = 0;
+		}
 	}
 
 	do_send();


### PR DESCRIPTION
不能每个 code 都对 length 进行重置, 仅当 length > 1000 才重置，否则永远无法压入队列