### PR TITLE
[fix] ParserUDP::subscribe()

### DIFF
--- a/src/ParserUDP/ParserUDP.cpp
+++ b/src/ParserUDP/ParserUDP.cpp
@@ -200,6 +200,11 @@ void ParserUDP::subscribe()
 		}
 	}
 
+    if (length > 0) {
+        StdUniqueLock lock(_mtx_queue);
+        _send_queue.push(data);
+    }
+
 	do_send();
 }
 


### PR DESCRIPTION
跳出循环后，如缓冲还有数据再最后推送一次