### PR TITLE
fix: avoid overflowing the real-value formatting buffer

### DIFF
--- a/src/Includes/WTSVariant.hpp
+++ b/src/Includes/WTSVariant.hpp
@@ -14,6 +14,7 @@
 #include "WTSCollection.hpp"
 
 #include <string>
+#include <cstdio>
 #include <string.h>
 #include <vector>
 #include <map>
@@ -104,9 +105,23 @@ private:
 	{
 		WTSVariant* ret = new WTSVariant();
 		ret->_type = VT_Real;
-		char s[32] = { 0 };
-		sprintf(s, "%.10f", _real);
-		ret->_value._string = new std::string(s);
+		int length = std::snprintf(nullptr, 0, "%.10f", _real);
+		if (length < 0)
+		{
+			ret->_value._string = new std::string();
+			return ret;
+		}
+
+		std::string value(static_cast<size_t>(length) + 1, '\0');
+		int written = std::snprintf(value.data(), value.size(), "%.10f", _real);
+		if (written < 0 || written > length)
+		{
+			ret->_value._string = new std::string();
+			return ret;
+		}
+
+		value.resize(static_cast<size_t>(written));
+		ret->_value._string = new std::string(value);
 		return ret;
 	}
 

--- a/src/TestUnits/test_wtsvariant.cpp
+++ b/src/TestUnits/test_wtsvariant.cpp
@@ -1,0 +1,13 @@
+#include "../Includes/WTSVariant.hpp"
+#include "gtest/gtest/gtest.h"
+
+TEST(test_wtsvariant, real_format_handles_large_values)
+{
+	wtp::WTSVariant* root = wtp::WTSVariant::createObject();
+	root->append("value", 6.022e23);
+
+	EXPECT_EQ(
+		root->getString("value"),
+		"602200000000000027262976.0000000000");
+	root->release();
+}


### PR DESCRIPTION
Fixes #273

`WTSVariant::create(double)` formatted values with `sprintf` into a
fixed 32-byte stack buffer. Large JSON numbers can exceed that buffer and
corrupt the stack.

Use a two-pass `snprintf` conversion with a dynamically sized string so the
existing fixed-point precision is preserved without truncation. Add a
regression test covering the reported `6.022e23` input.

Validation:
- `git diff --check`
- standalone C++17 formatting regression harness