### PR TITLE
fix: 引擎进程退出清理缺失导致无法干净退出, 补全release释放链

### DIFF
--- a/src/WtCore/WtCtaEngine.cpp
+++ b/src/WtCore/WtCtaEngine.cpp
@@ -40,14 +40,22 @@ WtCtaEngine::WtCtaEngine()
 
 WtCtaEngine::~WtCtaEngine()
 {
+	release();
+
+	if (_cfg)
+		_cfg->release();
+}
+
+void WtCtaEngine::release()
+{
 	if (_tm_ticker)
 	{
+		_tm_ticker->stop();
 		delete _tm_ticker;
 		_tm_ticker = NULL;
 	}
 
-	if (_cfg)
-		_cfg->release();
+	WtEngine::release();
 }
 
 void WtCtaEngine::run()

--- a/src/WtCore/WtCtaEngine.h
+++ b/src/WtCore/WtCtaEngine.h
@@ -40,6 +40,8 @@ public:
 
 	virtual void run() override;
 
+	virtual void release() override;
+
 	virtual void init(WTSVariant* cfg, IBaseDataMgr* bdMgr, WtDtMgr* dataMgr, IHotMgr* hotMgr, EventNotifier* notifier) override;
 
 	virtual bool isInTrading() override;

--- a/src/WtCore/WtEngine.cpp
+++ b/src/WtCore/WtEngine.cpp
@@ -1129,6 +1129,17 @@ void WtEngine::task_loop()
 	}
 }
 
+void WtEngine::release()
+{
+	_terminated = true;
+	_cond_task.notify_all();
+	if (_thrd_task)
+	{
+		_thrd_task->join();
+		_thrd_task.reset();
+	}
+}
+
 bool WtEngine::init_riskmon(WTSVariant* cfg)
 {
 	if (cfg == NULL)

--- a/src/WtCore/WtEngine.h
+++ b/src/WtCore/WtEngine.h
@@ -157,6 +157,9 @@ public:
 
 	virtual void run() = 0;
 
+	//停止引擎内部线程并释放资源, 子类先停自有ticker再调用基类版本
+	virtual void release();
+
 	virtual void on_tick(const char* stdCode, WTSTickData* curTick);
 
 	virtual void on_bar(const char* stdCode, const char* period, uint32_t times, WTSBarStruct* newBar) = 0;

--- a/src/WtCore/WtHftEngine.cpp
+++ b/src/WtCore/WtHftEngine.cpp
@@ -38,6 +38,14 @@ WtHftEngine::WtHftEngine()
 
 WtHftEngine::~WtHftEngine()
 {
+	release();
+
+	if (_cfg)
+		_cfg->release();
+}
+
+void WtHftEngine::release()
+{
 	if (_tm_ticker)
 	{
 		_tm_ticker->stop();
@@ -45,8 +53,7 @@ WtHftEngine::~WtHftEngine()
 		_tm_ticker = NULL;
 	}
 
-	if (_cfg)
-		_cfg->release();
+	WtEngine::release();
 }
 
 void WtHftEngine::init(WTSVariant* cfg, IBaseDataMgr* bdMgr, WtDtMgr* dataMgr, IHotMgr* hotMgr, EventNotifier* notifier /* = NULL */)

--- a/src/WtCore/WtHftEngine.h
+++ b/src/WtCore/WtHftEngine.h
@@ -33,6 +33,8 @@ public:
 
 	virtual void run() override;
 
+	virtual void release() override;
+
 	virtual void handle_push_quote(WTSTickData* newTick) override;
 	virtual void handle_push_order_detail(WTSOrdDtlData* curOrdDtl) override;
 	virtual void handle_push_order_queue(WTSOrdQueData* curOrdQue) override;

--- a/src/WtCore/WtSelEngine.cpp
+++ b/src/WtCore/WtSelEngine.cpp
@@ -39,6 +39,21 @@ WtSelEngine::WtSelEngine()
 
 WtSelEngine::~WtSelEngine()
 {
+	release();
+}
+
+void WtSelEngine::release()
+{
+	_terminated = true;
+
+	if (_tm_ticker)
+	{
+		_tm_ticker->stop();
+		delete _tm_ticker;
+		_tm_ticker = NULL;
+	}
+
+	WtEngine::release();
 }
 
 void WtSelEngine::on_session_end()

--- a/src/WtCore/WtSelEngine.h
+++ b/src/WtCore/WtSelEngine.h
@@ -53,6 +53,8 @@ public:
 
 	virtual void run() override;
 
+	virtual void release() override;
+
 	virtual void on_tick(const char* stdCode, WTSTickData* curTick) override;
 
 	virtual void on_bar(const char* stdCode, const char* period, uint32_t times, WTSBarStruct* newBar) override;

--- a/src/WtPorter/WtRtRunner.cpp
+++ b/src/WtPorter/WtRtRunner.cpp
@@ -1140,6 +1140,17 @@ void WtRtRunner::handleLogAppend(WTSLogLevel ll, const char* msg)
 
 void WtRtRunner::release()
 {
+	//置退出标记, 同步模式下run()内的等待循环得以返回
+	_to_exit = true;
+
+	//停止行情/交易适配器(内部线程由各API自行管理)
+	_parsers.release();
+	_traders.release();
+
+	//停止引擎内部ticker与任务线程
+	if (_engine)
+		_engine->release();
+
 	WTSLogger::stop();
 }
 


### PR DESCRIPTION
【问题背景】
wtpy实盘/仿真引擎(WtPorter)以动态库形式内嵌于宿主Python进程。
WtRtRunner是常驻单例, 内部持有ticker线程、引擎任务线程、行情/交易适配器等
后台资源。此前整个链路没有任何完整的退出清理机制。

【问题表现】
engine.release()后进程仍无法自然结束(run_porter的同步等待循环永不返回,
后台线程继续存活), 用户只能用TerminateProcess强杀自身进程,
导致进程退出码非0(1), CI脚本与调用方判定为异常失败;
且日志缓冲未flush, 末尾日志丢失。

【问题原因】
1) WtRtRunner::release()仅调用了WTSLogger::stop(), _parsers/_traders/
   _engine全部无人释放; 同步模式下run()内部的while(!_to_exit)等待循环
   也因_to_exit永远为false而无法返回。
2) WtEngine基类无release接口, 其任务线程在while(!_terminated)中阻塞于
   条件变量, 无停止机制。
3) WtCtaEngine析构直接delete _tm_ticker而未先stop(), 对joinable线程
   直接析构会触发std::terminate。

【问题修复】
1) WtEngine基类新增virtual release(): 置_terminated并notify_all唤醒、
   join任务线程; CTA/HFT/SEL三个引擎override release(), 先stop()各自
   ticker(join内部线程)再调用基类版本, 析构函数统一收敛到release(),
   保证幂等与二重释放安全。
2) WtRtRunner::release()补全清理链: 置_to_exit=true让同步run()循环返回,
   依次释放_parsers/_traders适配器, 调用_engine->release()停止引擎内部
   线程, 最后WTSLogger::stop()落盘日志。此后宿主进程可正常return 0退出。