### PR TITLE
fix: 引擎yaml配置中文路径加载失败, 配置字符串统一转本地ANSI

### DIFF
--- a/src/WTSUtils/WTSCfgLoader.cpp
+++ b/src/WTSUtils/WTSCfgLoader.cpp
@@ -8,6 +8,23 @@
 #include <rapidjson/document.h>
 namespace rj = rapidjson;
 
+//Win下窄字符文件接口(std::filesystem/ifstream等)按ANSI代码页解释char*,
+//而Python端经ctypes传入的配置内容(json的\uXXXX转义、yaml原文)最终解析出的是UTF-8编码
+//的字符串值, 含中文时必须转为本地ANSI编码, 否则下游所有以"文件路径"形态消费该值的
+//调用方(loadSessions/loadCommodities等的exists检查与打开文件)均会因乱码路径失败。
+//纯ASCII内容不受影响; 已是ANSI编码的字节序列不满足合法UTF-8特征, 同样跳过转换。
+static std::string to_local_str(const std::string& src)
+{
+#ifdef _WIN32
+	if (!src.empty())
+	{
+		UTF8toChar conv(src);
+		return std::string(conv.c_str());
+	}
+#endif
+	return src;
+}
+
 
 bool json_to_variant(const rj::Value& root, WTSVariant* params)
 {
@@ -52,8 +69,11 @@ bool json_to_variant(const rj::Value& root, WTSVariant* params)
 					params->append(key, item.GetDouble());
 				break;
 			case rj::kStringType:
-				params->append(key, item.GetString());
-				break;
+			{
+				std::string val = to_local_str(item.GetString());
+				params->append(key, val.c_str());
+			}
+			break;
 			case rj::kTrueType:
 			case rj::kFalseType:
 				params->append(key, item.GetBool());
@@ -95,8 +115,11 @@ bool json_to_variant(const rj::Value& root, WTSVariant* params)
 					params->append(item.GetDouble());
 				break;
 			case rj::kStringType:
-				params->append(item.GetString());
-				break;
+			{
+				std::string val = to_local_str(item.GetString());
+				params->append(val.c_str());
+			}
+			break;
 			case rj::kTrueType:
 			case rj::kFalseType:
 				params->append(item.GetBool());
@@ -167,9 +190,15 @@ bool yaml_to_variant(const YAML::Node& root, WTSVariant* params)
 		break;
 		case YAML::NodeType::Scalar:
 			if (isMap)
-				params->append(key.c_str(), item.as<std::string>().c_str());
+			{
+				std::string val = to_local_str(item.as<std::string>());
+				params->append(key.c_str(), val.c_str());
+			}
 			else
-				params->append(item.as<std::string>().c_str());
+			{
+				std::string val = to_local_str(item.as<std::string>());
+				params->append(val.c_str());
+			}
 			break;
 		}
 	}
@@ -221,11 +250,25 @@ WTSVariant* WTSCfgLoader::load_from_content(const std::string& content, bool isY
 
 WTSVariant* WTSCfgLoader::load_from_file(const char* filename)
 {
-	if (!StdFile::exists(filename))
+	//Win下窄字符文件接口按ANSI编码解释路径, 外部传入的配置文件路径常为UTF-8编码,
+	//含中文时需先转为本地ANSI; 纯ASCII或已是ANSI编码的路径不做转换
+	std::string raw_name;
+	UTF8toChar name_conv("");
+	const char* real_path = filename;
+#ifdef _WIN32
+	raw_name = filename;
+	if (EncodingHelper::isUtf8((unsigned char*)raw_name.data(), raw_name.size()))
+	{
+		name_conv.init(raw_name.c_str());
+		real_path = name_conv.c_str();
+	}
+#endif
+
+	if (!StdFile::exists(real_path))
 		return NULL;
 
 	std::string content;
-	StdFile::read_file_content(filename, content);
+	StdFile::read_file_content(real_path, content);
 	if (content.empty())
 		return NULL;
 

--- a/src/WtPorter/WtPorter.cpp
+++ b/src/WtPorter/WtPorter.cpp
@@ -16,6 +16,10 @@
 #include "../Includes/WTSVersion.h"
 
 #ifdef _WIN32
+#include "../Share/charconv.hpp"
+#endif
+
+#ifdef _WIN32
 #   ifdef _WIN64
     char PLATFORM_NAME[] = "X64";
 #   else
@@ -101,6 +105,17 @@ void init_porter(const char* logProfile, bool isFile, const char* genDir)
 	if (inited)
 		return;
 
+#ifdef _WIN32
+	//Python层传入的路径为UTF-8字节, 而Win下窄字符文件接口按ANSI编码解释,
+	//含非ASCII字符(如中文)的路径需先转为本地ANSI编码, 否则报文件不存在
+	UTF8toChar log_conv(logProfile);
+	if (isFile)
+		logProfile = log_conv.c_str();
+
+	UTF8toChar gen_conv(genDir);
+	genDir = gen_conv.c_str();
+#endif
+
 	getRunner().init(logProfile, isFile, genDir);
 
 	inited = true;
@@ -111,7 +126,15 @@ void config_porter(const char* cfgfile, bool isFile)
 	if (strlen(cfgfile) == 0)
 		getRunner().config("config.json", true);
 	else
+	{
+#ifdef _WIN32
+		//路径编码转换, 参见init_porter注释; 内容模式下为配置文本, 不可转换
+		UTF8toChar cfg_conv(cfgfile);
+		if (isFile)
+			cfgfile = cfg_conv.c_str();
+#endif
 		getRunner().config(cfgfile, isFile);
+	}
 }
 
 void run_porter(bool bAsync)


### PR DESCRIPTION
【问题背景】
wtpy实盘引擎的配置链路为: Python侧yaml/json -> engine.init读取 -> commitConfig 以json.dumps(ensure_ascii=True)输出纯ASCII文本经ctypes传入WtPorter动态库, rapidjson把unicode转义解码成UTF-8编码的std::string存入WTSVariant。 C++端各处文件访问(StdFile/std::filesystem/ifstream等窄字符接口)在Windows下 按ANSI代码页解释路径字节, 因此配置链路里所有以"文件路径"形态消费的字符串值
都必须是本地ANSI编码才能打开。

【问题表现】
yaml配置中basefiles子路径(commodity/contract/session等指向含中文目录的 基础数据文件)加载失败, 日志报 xxx configuration file ... not exists, 即使文件真实存在; 位于中文目录下的logcfg.yaml/genDir等入口参数同理失败。

【问题原因】
原内容级编码转换(WTSCfgLoader::load_from_content对整体文本做UTF8toChar) 无法覆盖经由ensure_ascii纯ASCII通道进入的值: 全文纯ASCII使isUtf8检测通过 但UTF8toChar透传, \uXXXX由rapidjson解码为内部UTF-8存储, 中文路径以错误编码 流入下游; 且sessions/commodities/contracts/holidays及parsers/traders/ executers的加载入口分散在多处, 各自先做StdFile::exists自查后才调用
WTSCfgLoader::load_from_file, 单点修补该函数无法覆盖全部前置检查。

【问题修复】
1) WTSCfgLoader新增to_local_str辅助: Win下将UTF-8编码字符串转为本地ANSI,
   纯ASCII与已是ANSI的字节序列(不满足合法UTF-8特征)自动跳过;
2) json_to_variant/yaml_to_variant的全部标量字符串叶子统一经to_local_str
   落库, 作为配置字符串进入variant容器的唯一关口, 一次性覆盖所有下游消费方
   (基础文件加载/行情交易执行器分文件/fees/filters/风控模块名等);
3) WTSCfgLoader::load_from_file入口同步做路径级转换, 兜底覆盖CLI直接传参的
   独立Runner等场景;
4) WtPorter.cpp的init_porter(logProfile仅isFile时)/genDir与config_porter
   (cfgfile仅isFile时)出口参数同规则转换; 内容模式(isFile=false)为配置文本,
   维持原有转换逻辑。Linux窄字符接口本身即UTF-8, 相关代码均不参与编译。