### PR TITLE
fix: SEL引擎分钟周期(TPT_Minute)定时任务永不可达

### DIFF
--- a/src/ParserCTP/ParserCTP.vcxproj
+++ b/src/ParserCTP/ParserCTP.vcxproj
@@ -42,14 +42,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/ParserCTPMini/ParserCTPMini.vcxproj
+++ b/src/ParserCTPMini/ParserCTPMini.vcxproj
@@ -42,14 +42,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/ParserCTPOpt/ParserCTPOpt.vcxproj
+++ b/src/ParserCTPOpt/ParserCTPOpt.vcxproj
@@ -42,14 +42,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/ParserFemas/ParserFemas.vcxproj
+++ b/src/ParserFemas/ParserFemas.vcxproj
@@ -42,14 +42,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/ParserHuaX/ParserHuaX.vcxproj
+++ b/src/ParserHuaX/ParserHuaX.vcxproj
@@ -58,42 +58,42 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Wtpy|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Trade|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Wtpy|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Trade|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/ParserXTP/ParserXTP.vcxproj
+++ b/src/ParserXTP/ParserXTP.vcxproj
@@ -42,14 +42,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/ParserYD/ParserYD.vcxproj
+++ b/src/ParserYD/ParserYD.vcxproj
@@ -42,14 +42,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/WTSUtils/WTSCfgLoader.cpp
+++ b/src/WTSUtils/WTSCfgLoader.cpp
@@ -8,6 +8,23 @@
 #include <rapidjson/document.h>
 namespace rj = rapidjson;
 
+//Win下窄字符文件接口(std::filesystem/ifstream等)按ANSI代码页解释char*,
+//而Python端经ctypes传入的配置内容(json的\uXXXX转义、yaml原文)最终解析出的是UTF-8编码
+//的字符串值, 含中文时必须转为本地ANSI编码, 否则下游所有以"文件路径"形态消费该值的
+//调用方(loadSessions/loadCommodities等的exists检查与打开文件)均会因乱码路径失败。
+//纯ASCII内容不受影响; 已是ANSI编码的字节序列不满足合法UTF-8特征, 同样跳过转换。
+static std::string to_local_str(const std::string& src)
+{
+#ifdef _WIN32
+	if (!src.empty())
+	{
+		UTF8toChar conv(src);
+		return std::string(conv.c_str());
+	}
+#endif
+	return src;
+}
+
 
 bool json_to_variant(const rj::Value& root, WTSVariant* params)
 {
@@ -52,8 +69,11 @@ bool json_to_variant(const rj::Value& root, WTSVariant* params)
 					params->append(key, item.GetDouble());
 				break;
 			case rj::kStringType:
-				params->append(key, item.GetString());
-				break;
+			{
+				std::string val = to_local_str(item.GetString());
+				params->append(key, val.c_str());
+			}
+			break;
 			case rj::kTrueType:
 			case rj::kFalseType:
 				params->append(key, item.GetBool());
@@ -95,8 +115,11 @@ bool json_to_variant(const rj::Value& root, WTSVariant* params)
 					params->append(item.GetDouble());
 				break;
 			case rj::kStringType:
-				params->append(item.GetString());
-				break;
+			{
+				std::string val = to_local_str(item.GetString());
+				params->append(val.c_str());
+			}
+			break;
 			case rj::kTrueType:
 			case rj::kFalseType:
 				params->append(item.GetBool());
@@ -167,9 +190,15 @@ bool yaml_to_variant(const YAML::Node& root, WTSVariant* params)
 		break;
 		case YAML::NodeType::Scalar:
 			if (isMap)
-				params->append(key.c_str(), item.as<std::string>().c_str());
+			{
+				std::string val = to_local_str(item.as<std::string>());
+				params->append(key.c_str(), val.c_str());
+			}
 			else
-				params->append(item.as<std::string>().c_str());
+			{
+				std::string val = to_local_str(item.as<std::string>());
+				params->append(val.c_str());
+			}
 			break;
 		}
 	}
@@ -221,11 +250,25 @@ WTSVariant* WTSCfgLoader::load_from_content(const std::string& content, bool isY
 
 WTSVariant* WTSCfgLoader::load_from_file(const char* filename)
 {
-	if (!StdFile::exists(filename))
+	//Win下窄字符文件接口按ANSI编码解释路径, 外部传入的配置文件路径常为UTF-8编码,
+	//含中文时需先转为本地ANSI; 纯ASCII或已是ANSI编码的路径不做转换
+	std::string raw_name;
+	UTF8toChar name_conv("");
+	const char* real_path = filename;
+#ifdef _WIN32
+	raw_name = filename;
+	if (EncodingHelper::isUtf8((unsigned char*)raw_name.data(), raw_name.size()))
+	{
+		name_conv.init(raw_name.c_str());
+		real_path = name_conv.c_str();
+	}
+#endif
+
+	if (!StdFile::exists(real_path))
 		return NULL;
 
 	std::string content;
-	StdFile::read_file_content(filename, content);
+	StdFile::read_file_content(real_path, content);
 	if (content.empty())
 		return NULL;
 

--- a/src/WtBtCore/HisDataReplayer.cpp
+++ b/src/WtBtCore/HisDataReplayer.cpp
@@ -2412,7 +2412,9 @@ WTSKlineSlice* HisDataReplayer::get_kline_slice(const char* stdCode, const char*
 		uint32_t curMin = (_cur_date - 19900000) * 10000 + _cur_time;
 		if (isDay)
 		{
-			if (kBlkPair->_cursor <= kBlkPair->_count)
+			//首次定位时若目标bar晚于当前交易日(如标的尚未上市), _cursor会被置为0
+			//此时必须跳过本分支, 否则 _bars[_cursor-1] 会越界访问 _bars[-1]
+			if (kBlkPair->_cursor > 0 && kBlkPair->_cursor <= kBlkPair->_count)
 			{
 				if(!isClosed)
 				{
@@ -2436,7 +2438,8 @@ WTSKlineSlice* HisDataReplayer::get_kline_slice(const char* stdCode, const char*
 		}
 		else
 		{
-			if (kBlkPair->_cursor <= kBlkPair->_count)
+			//同上, 分钟线首次定位为未上市/未来标的时 _cursor 也可能为0, 避免 _bars[-1] 越界
+			if (kBlkPair->_cursor > 0 && kBlkPair->_cursor <= kBlkPair->_count)
 			{
 				while (kBlkPair->_bars[kBlkPair->_cursor-1].time < curMin && kBlkPair->_cursor < kBlkPair->_count)
 				{

--- a/src/WtBtCore/HisDataReplayer.cpp
+++ b/src/WtBtCore/HisDataReplayer.cpp
@@ -1173,6 +1173,13 @@ void HisDataReplayer::run_by_tasks(bool bNeedDump /* = false */)
 						_cur_date = _cur_tdate;
 					}
 				}
+				else
+				{
+					//白盘会话(时间偏移为0), 夜盘算作当天, 这里必须整体推进交易日
+					//否则 _cur_date 会停留在旧交易日, 导致 nextTime 永不前进, 回测死循环
+					_cur_date = nextTDate;
+					_cur_tdate = nextTDate;
+				}
 
 				_cur_time = sInfo->minuteToTime(mins);
 

--- a/src/WtBtCore/HisDataReplayer.cpp
+++ b/src/WtBtCore/HisDataReplayer.cpp
@@ -1064,6 +1064,16 @@ void HisDataReplayer::run_by_tasks(bool bNeedDump /* = false */)
 				if (_listener)
 					_listener->handle_session_begin(_cur_tdate);
 				check_cache_days();
+
+				/*
+				 *	日频及以上周期任务(TPT_Daily/Monthly/Weekly/Yearly)触发时, 也按开高低收同步模拟tick
+				 *	否则撮合器拿不到任何价格, 策略信号将永不成交
+				 *	与下方 TPT_Minute 分支的 tick 模拟机制保持一致
+				 */
+				for (int i = 0; i < 4; i++)
+				{
+					simTicks(curDate, curTime, (bEndSession ? _cur_tdate : preTDate), i);
+				}
 				onMinuteEnd(curDate, curTime, bEndSession ? _cur_tdate : preTDate);
 				if (_listener)
 					_listener->handle_session_end(_cur_tdate);

--- a/src/WtBtCore/SelMocker.cpp
+++ b/src/WtBtCore/SelMocker.cpp
@@ -491,15 +491,24 @@ bool SelMocker::on_schedule(uint32_t curDate, uint32_t curTime, uint32_t fireTim
 	{
 		const PosInfo& pInfo = v.second;
 		const char* code = v.first.c_str();
-		if(_sig_map.find(code) == _sig_map.end() && !decimal::eq(pInfo._volume, 0.0))
+		//持仓为0的不处理
+		if (decimal::eq(pInfo._volume, 0.0))
+			continue;
+
+		//autoexit 判断依据应为"策略申明的目标仓位", 而不是"本轮是否有信号"
+		//因为 stra_set_position 在目标=当前持仓时会幂等跳过(不产生信号),
+		//若按信号判断, 持仓=目标时会被误清仓, 导致每轮买卖循环
+		auto it = _target_map.find(code);
+		if (it == _target_map.end() || decimal::eq(it->second, 0.0))
 		{
-			//新的信号中没有该持仓,则要清空
+			//策略未申明目标, 或目标为0, 则清仓
 			to_clear.insert(code);
 		}
 	}
 
 	for(const std::string& code : to_clear)
 	{
+		_target_map[code] = 0.0;
 		append_signal(code.c_str(), 0, "autoexit");
 	}
 
@@ -602,6 +611,10 @@ void SelMocker::stra_set_position(const char* stdCode, double qty, const char* u
 		log_error("Cannot short on {}", stdCode);
 		return;
 	}
+
+	//记录目标仓位(autoexit 判断依据), 幂等跳过时也要记录
+	//否则当"目标=当前持仓"直接返回时, 后续调度会因本轮无信号被 autoexit 误清仓
+	_target_map[stdCode] = qty;
 
 	double total = stra_get_position(stdCode, false);
 	//如果目标仓位和当前仓位是一致的，直接退出

--- a/src/WtBtCore/SelMocker.h
+++ b/src/WtBtCore/SelMocker.h
@@ -246,6 +246,12 @@ protected:
 	typedef wt_hashmap<std::string, SigInfo>	SignalMap;
 	SignalMap		_sig_map;
 
+	//策略最后申明的目标仓位(autoexit 判断依据)
+	//stra_set_position 在"目标=当前持仓"时会幂等跳过(不产生信号),
+	//若 autoexit 依据"本轮是否有信号"判断, 持仓=目标时会被误清仓, 造成每轮买卖循环
+	typedef wt_hashmap<std::string, double>		TargetMap;
+	TargetMap		_target_map;
+
 	std::stringstream	_trade_logs;
 	std::stringstream	_close_logs;
 	std::stringstream	_fund_logs;

--- a/src/WtCore/SelStraBaseCtx.cpp
+++ b/src/WtCore/SelStraBaseCtx.cpp
@@ -609,15 +609,24 @@ bool SelStraBaseCtx::on_schedule(uint32_t curDate, uint32_t curTime, uint32_t fi
 	{
 		const PosInfo& pInfo = v.second;
 		const char* code = v.first.c_str();
-		if (_sig_map.find(code) == _sig_map.end() && !decimal::eq(pInfo._volume, 0.0))
+		//持仓为0的不处理
+		if (decimal::eq(pInfo._volume, 0.0))
+			continue;
+
+		//autoexit 判断依据应为"策略申明的目标仓位", 而不是"本轮是否有信号"
+		//因为 stra_set_position 在目标=当前持仓时会幂等跳过(不产生信号),
+		//若按信号判断, 持仓=目标时会被误清仓, 导致每轮买卖循环
+		auto it = _target_map.find(code);
+		if (it == _target_map.end() || decimal::eq(it->second, 0.0))
 		{
-			//新的信号中没有该持仓,则要清空
+			//策略未申明目标, 或目标为0, 则清仓
 			to_clear.insert(code);
 		}
 	}
 
 	for (const std::string& code : to_clear)
 	{
+		_target_map[code] = 0.0;
 		append_signal(code.c_str(), 0, "autoexit");
 	}
 
@@ -751,6 +760,10 @@ void SelStraBaseCtx::stra_set_position(const char* stdCode, double qty, const ch
 		log_error("Cannot short on {}", stdCode);
 		return;
 	}
+
+	//记录目标仓位(autoexit 判断依据), 幂等跳过时也要记录
+	//否则当"目标=当前持仓"直接返回时, 后续调度会因本轮无信号被 autoexit 误清仓
+	_target_map[stdCode] = qty;
 
 	double total = stra_get_position(stdCode, false);
 	//如果目标仓位和当前仓位是一致的，直接退出

--- a/src/WtCore/SelStraBaseCtx.h
+++ b/src/WtCore/SelStraBaseCtx.h
@@ -223,6 +223,12 @@ protected:
 	typedef wt_hashmap<std::string, SigInfo>	SignalMap;
 	SignalMap		_sig_map;
 
+	//策略最后申明的目标仓位(autoexit 判断依据)
+	//stra_set_position 在"目标=当前持仓"时会幂等跳过(不产生信号),
+	//若 autoexit 依据"本轮是否有信号"判断, 持仓=目标时会被误清仓, 造成每轮买卖循环
+	typedef wt_hashmap<std::string, double>		TargetMap;
+	TargetMap		_target_map;
+
 	BoostFilePtr	_trade_logs;
 	BoostFilePtr	_close_logs;
 	BoostFilePtr	_fund_logs;

--- a/src/WtCore/WtCtaEngine.cpp
+++ b/src/WtCore/WtCtaEngine.cpp
@@ -40,14 +40,22 @@ WtCtaEngine::WtCtaEngine()
 
 WtCtaEngine::~WtCtaEngine()
 {
+	release();
+
+	if (_cfg)
+		_cfg->release();
+}
+
+void WtCtaEngine::release()
+{
 	if (_tm_ticker)
 	{
+		_tm_ticker->stop();
 		delete _tm_ticker;
 		_tm_ticker = NULL;
 	}
 
-	if (_cfg)
-		_cfg->release();
+	WtEngine::release();
 }
 
 void WtCtaEngine::run()

--- a/src/WtCore/WtCtaEngine.h
+++ b/src/WtCore/WtCtaEngine.h
@@ -40,6 +40,8 @@ public:
 
 	virtual void run() override;
 
+	virtual void release() override;
+
 	virtual void init(WTSVariant* cfg, IBaseDataMgr* bdMgr, WtDtMgr* dataMgr, IHotMgr* hotMgr, EventNotifier* notifier) override;
 
 	virtual bool isInTrading() override;

--- a/src/WtCore/WtEngine.cpp
+++ b/src/WtCore/WtEngine.cpp
@@ -1129,6 +1129,17 @@ void WtEngine::task_loop()
 	}
 }
 
+void WtEngine::release()
+{
+	_terminated = true;
+	_cond_task.notify_all();
+	if (_thrd_task)
+	{
+		_thrd_task->join();
+		_thrd_task.reset();
+	}
+}
+
 bool WtEngine::init_riskmon(WTSVariant* cfg)
 {
 	if (cfg == NULL)

--- a/src/WtCore/WtEngine.h
+++ b/src/WtCore/WtEngine.h
@@ -157,6 +157,9 @@ public:
 
 	virtual void run() = 0;
 
+	//停止引擎内部线程并释放资源, 子类先停自有ticker再调用基类版本
+	virtual void release();
+
 	virtual void on_tick(const char* stdCode, WTSTickData* curTick);
 
 	virtual void on_bar(const char* stdCode, const char* period, uint32_t times, WTSBarStruct* newBar) = 0;

--- a/src/WtCore/WtHftEngine.cpp
+++ b/src/WtCore/WtHftEngine.cpp
@@ -38,6 +38,14 @@ WtHftEngine::WtHftEngine()
 
 WtHftEngine::~WtHftEngine()
 {
+	release();
+
+	if (_cfg)
+		_cfg->release();
+}
+
+void WtHftEngine::release()
+{
 	if (_tm_ticker)
 	{
 		_tm_ticker->stop();
@@ -45,8 +53,7 @@ WtHftEngine::~WtHftEngine()
 		_tm_ticker = NULL;
 	}
 
-	if (_cfg)
-		_cfg->release();
+	WtEngine::release();
 }
 
 void WtHftEngine::init(WTSVariant* cfg, IBaseDataMgr* bdMgr, WtDtMgr* dataMgr, IHotMgr* hotMgr, EventNotifier* notifier /* = NULL */)

--- a/src/WtCore/WtHftEngine.h
+++ b/src/WtCore/WtHftEngine.h
@@ -33,6 +33,8 @@ public:
 
 	virtual void run() override;
 
+	virtual void release() override;
+
 	virtual void handle_push_quote(WTSTickData* newTick) override;
 	virtual void handle_push_order_detail(WTSOrdDtlData* curOrdDtl) override;
 	virtual void handle_push_order_queue(WTSOrdQueData* curOrdQue) override;

--- a/src/WtCore/WtSelEngine.cpp
+++ b/src/WtCore/WtSelEngine.cpp
@@ -233,8 +233,6 @@ void WtSelEngine::on_minute_end(uint32_t curDate, uint32_t curTime)
 	for (auto& v : _tasks)
 	{
 		TaskInfoPtr& tInfo = (TaskInfoPtr&)v.second;
-		if (tInfo->_time != nextTime)
-			continue;
 
 		uint64_t now = (uint64_t)curDate * 10000 + nextTime;
 		if (tInfo->_last_exe_time >= now)
@@ -258,15 +256,24 @@ void WtSelEngine::on_minute_end(uint32_t curDate, uint32_t curTime)
 		WTSSessionInfo* sInfo = get_session_info(tInfo->_session, false);
 
 		bool bIgnore = true;
+
+		/*
+		 *	触发条件按周期分别判定: D/W/M/Y为时刻(_time, HHMM)与nextTime精确匹配后叠加原有日历条件;
+		 *	Minute周期以下一分钟(nextTime)换算的会话内分钟序号对_time取模.
+		 *	原实现将时刻匹配作为所有周期的公共前置门, 与Minute的间隔语义矛盾导致该分支永不可达;
+		 *	盘外时间timeToMinutes返回INVALID_UINT32, 此处天然不触发.
+		 */
 		switch (tInfo->_period)
 		{
 		case TPT_Daily:
+			if (tInfo->_time != nextTime)
+				break;
 			bIgnore = false;
 			break;
 		case TPT_Minute:
 			{
-				uint32_t minutes = sInfo->timeToMinutes(curTime);	//先将时间转换成分钟数
-				if(minutes != 0 && (minutes%tInfo->_time == 0))		//如果分钟数能被整除,且不为0,则可以触发
+				uint32_t minutes = (sInfo == NULL) ? INVALID_UINT32 : sInfo->timeToMinutes(nextTime);	//先将下一分钟的触发时刻转换成会话内分钟数
+				if(minutes != INVALID_UINT32 && minutes != 0 && (minutes%tInfo->_time == 0))			//如果分钟数能被整除,且不为0,则可以触发
 				{
 					bIgnore = false;
 				}
@@ -275,6 +282,8 @@ void WtSelEngine::on_minute_end(uint32_t curDate, uint32_t curTime)
 		case TPT_Monthly:
 			//if (preTDate % 1000000 < _task->_day && _cur_date % 1000000 >= _task->_day)
 			//	fired = true;
+			if (tInfo->_time != nextTime)
+				break;
 			if (_cur_date % 1000000 == tInfo->_day)
 				bIgnore = false;
 			else if (bHasHoliday)
@@ -295,6 +304,8 @@ void WtSelEngine::on_minute_end(uint32_t curDate, uint32_t curTime)
 		case TPT_Weekly:
 			//if (preWD < _task->_day && weekDay >= _task->_day)
 			//	fired = true;
+			if (tInfo->_time != nextTime)
+				break;
 			if (weekDay == tInfo->_day)
 				bIgnore = false;
 			else if (bHasHoliday)
@@ -315,8 +326,10 @@ void WtSelEngine::on_minute_end(uint32_t curDate, uint32_t curTime)
 			}
 			break;
 		case TPT_Yearly:
-			if (preTDate % 10000 < tInfo->_day && _cur_date % 10000 >= tInfo->_day)
+			if (tInfo->_time == nextTime && preTDate % 10000 < tInfo->_day && _cur_date % 10000 >= tInfo->_day)
 				bIgnore = false;
+			break;
+		default:
 			break;
 		}
 

--- a/src/WtCore/WtSelEngine.cpp
+++ b/src/WtCore/WtSelEngine.cpp
@@ -39,6 +39,21 @@ WtSelEngine::WtSelEngine()
 
 WtSelEngine::~WtSelEngine()
 {
+	release();
+}
+
+void WtSelEngine::release()
+{
+	_terminated = true;
+
+	if (_tm_ticker)
+	{
+		_tm_ticker->stop();
+		delete _tm_ticker;
+		_tm_ticker = NULL;
+	}
+
+	WtEngine::release();
 }
 
 void WtSelEngine::on_session_end()

--- a/src/WtCore/WtSelEngine.h
+++ b/src/WtCore/WtSelEngine.h
@@ -53,6 +53,8 @@ public:
 
 	virtual void run() override;
 
+	virtual void release() override;
+
 	virtual void on_tick(const char* stdCode, WTSTickData* curTick) override;
 
 	virtual void on_bar(const char* stdCode, const char* period, uint32_t times, WTSBarStruct* newBar) override;

--- a/src/WtPorter/WtPorter.cpp
+++ b/src/WtPorter/WtPorter.cpp
@@ -16,6 +16,10 @@
 #include "../Includes/WTSVersion.h"
 
 #ifdef _WIN32
+#include "../Share/charconv.hpp"
+#endif
+
+#ifdef _WIN32
 #   ifdef _WIN64
     char PLATFORM_NAME[] = "X64";
 #   else
@@ -101,6 +105,17 @@ void init_porter(const char* logProfile, bool isFile, const char* genDir)
 	if (inited)
 		return;
 
+#ifdef _WIN32
+	//Python层传入的路径为UTF-8字节, 而Win下窄字符文件接口按ANSI编码解释,
+	//含非ASCII字符(如中文)的路径需先转为本地ANSI编码, 否则报文件不存在
+	UTF8toChar log_conv(logProfile);
+	if (isFile)
+		logProfile = log_conv.c_str();
+
+	UTF8toChar gen_conv(genDir);
+	genDir = gen_conv.c_str();
+#endif
+
 	getRunner().init(logProfile, isFile, genDir);
 
 	inited = true;
@@ -111,7 +126,15 @@ void config_porter(const char* cfgfile, bool isFile)
 	if (strlen(cfgfile) == 0)
 		getRunner().config("config.json", true);
 	else
+	{
+#ifdef _WIN32
+		//路径编码转换, 参见init_porter注释; 内容模式下为配置文本, 不可转换
+		UTF8toChar cfg_conv(cfgfile);
+		if (isFile)
+			cfgfile = cfg_conv.c_str();
+#endif
 		getRunner().config(cfgfile, isFile);
+	}
 }
 
 void run_porter(bool bAsync)

--- a/src/WtPorter/WtRtRunner.cpp
+++ b/src/WtPorter/WtRtRunner.cpp
@@ -1140,6 +1140,17 @@ void WtRtRunner::handleLogAppend(WTSLogLevel ll, const char* msg)
 
 void WtRtRunner::release()
 {
+	//置退出标记, 同步模式下run()内的等待循环得以返回
+	_to_exit = true;
+
+	//停止行情/交易适配器(内部线程由各API自行管理)
+	_parsers.release();
+	_traders.release();
+
+	//停止引擎内部ticker与任务线程
+	if (_engine)
+		_engine->release();
+
 	WTSLogger::stop();
 }
 


### PR DESCRIPTION
问题背景：
SEL引擎支持按日/周/月/年/分钟的周期性定时调度，由add_sel_strategy(date, time, period)
注册任务，预期period=min时每N分钟触发一次策略调度回调on_calculate。
回测引擎(WtBtCore)对相同参数工作完全正常。

问题表现：
生产环境中注册的分钟周期任务从未触发任何一次调度：策略仅收到on_init回调，
交易时段内没有任何on_schedule/on_calculate产生，实盘策略全程无动作；
日志中分钟闭合正常，但无任何任务派发痕迹。

问题原因：
WtSelEngine::on_minute_end将时刻精确匹配(_time==nextTime)作为所有周期任务的
公共前置门（nextTime为HHMM格式的下一分钟），而TPT_Minute周期的_time语义为
间隔分钟数N，二者永不相等；switch内基于minutes%_time的周期判定分支因此
永远不可达，形成死代码。回测引擎为独立实现，不存在该公共门，缺陷被长期掩盖。
此外原实现对于交易时段外的时间未做防御，timeToMinutes返回INVALID_UINT32后
参与取模运算属未定义行为。

问题修复：
将时刻/周期匹配逻辑归位到switch各周期分支内统一处理：
- D/W/M/Y：维持_time与nextTime精确匹配后叠加原有日历条件，行为与原实现等价；
- Minute：以下一分钟(nextTime)换算的会话内分钟序号对_time取模，
  盘外时间timeToMinutes返回INVALID_UINT32天然守卫不触发；
- 补充sInfo空指针保护。