### PR TITLE
fix: SEL引擎任务上次执行时间未初始化致调度随机失效

### DIFF
--- a/src/WtCore/WtSelEngine.h
+++ b/src/WtCore/WtSelEngine.h
@@ -29,7 +29,7 @@ typedef struct _TaskInfo
 	uint32_t	_time;			//时间,精确到分钟
 	bool		_strict_time;	//是否是严格时间,严格时间即只有时间相等才会执行,不是严格时间,则大于等于触发时间都会执行
 
-	uint64_t	_last_exe_time;	//上次执行时间,主要为了防止重复执行
+	uint64_t	_last_exe_time = 0;	//上次执行时间,主要为了防止重复执行; POD结构体new时不初始化, 堆残留值可能令调度被永久跳过
 
 	TaskPeriodType	_period;	//任务周期
 } TaskInfo;


### PR DESCRIPTION
问题背景:
SEL引擎(WtSelEngine)为每个策略上下文注册TaskInfo定时任务, on_minute_end 以"上次执行时间<本次触发时间"去重防止重复调度。TaskInfo为POD结构体,
注册路径WtSelEngine::addContext中对各字段逐一显式赋值。

问题表现:
同一进程内bar闭合事件(on_minute_end)正常到达, 但任务调度随机失效:
相同代码/配置/数据下, 有的进程每分钟正常调度, 有的进程全程无任何调度,
策略静默空跑, 日志无任何错误。

问题原因:
TaskInfo::_last_exe_time为POD标量成员, addContext未对其赋值, new TaskInfo 不清零, 其值为堆上残留内存。on_minute_end以"tInfo->_last_exe_time >= now 则跳过"作去重门限(now为日期*10000+HHMM, 约2e11), 残留值恰为指针等大整数
时任务被永久跳过, 因此表现为随进程堆状态而异的随机失效。

问题修复:
为_last_exe_time添加类内初始化器(=0), 语义即"从未执行过", 消除对堆残留
值的依赖。0小于任何合法时间戳, 首次调度判定恒通过, 去重语义不变。

验证:
实盘仿真环境(WT_DRY_RUN演练)部署后引擎每分钟稳定调度, 策略决策正常触发。