### PR TITLE
fix: SEL引擎ticker时间格式不一致致首次本地闭合后引擎永久静默

### DIFF
--- a/src/WtCore/WtSelTicker.cpp
+++ b/src/WtCore/WtSelTicker.cpp
@@ -189,7 +189,9 @@ void WtSelRtTicker::run()
 					_last_emit_pos = _cur_pos;
 
 					uint32_t thisMin = _s_info->minuteToTime(_cur_pos);
-					_time = thisMin;
+					//_time全链路约定为HHMMSSmmm格式(on_tick/getDateTime写入, isInTradingTime(_time/100000)读取),
+					//此处必须换算, 直接写HHMM会使后续判定误入盘外分支并将交易日误滚动到次日
+					_time = thisMin * 100000;
 
 					//如果thisMin是0, 说明换日了
 					//这里是本地计时导致的换日, 说明日期其实还是老日期, 要自动+1
@@ -222,10 +224,11 @@ void WtSelRtTicker::run()
 			else
 			{//如果不在交易时间,则每隔10毫秒检查一次,如果分钟发生变化则触发
 				std::this_thread::sleep_for(std::chrono::milliseconds(10));
-				uint32_t curTime = TimeUtils::getCurMin();
+				//getCurMin返回HHMMSS, 与_time的HHMMSSmmm约定差一个毫秒位, 不换算会导致跨日误判
+				uint32_t curTime = TimeUtils::getCurMin() * 1000;
 				if (_time != UINT_MAX && curTime != _time)
 				{
-					_engine->on_minute_end(_date, _time);
+					_engine->on_minute_end(_date, _time / 100000);
 					if (curTime < _time)
 						_date = TimeUtils::getNextDate(_date);
 					_time = curTime;


### PR DESCRIPTION
问题背景:
WtSelRtTicker驱动SEL引擎时钟: on_tick用行情actionTime(HHMMSSmmm, 9位) 推进会话分钟位置, 跨分钟时触发bar闭合; 本地定时线程在分钟边界兜底闭合
(closed automatically); 盘外分支按本地时钟处理换日。_time成员由init的 TimeUtils::getDateTime写入, 约定为HHMMSSmmm格式。

问题表现:
引擎启动后前1~2分钟闭合与调度正常, 之后行情tick持续到达但bar闭合、
任务调度全部停止, 引擎永久静默且无任何错误日志。使用逐分钟批量推送
伪tick的实盘数据源时必现, 每秒级推送的数据源因不走本地闭合路径而
不触发。

问题原因:
_time存在三种写入格式: on_tick写HHMMSSmmm(9位), 本地闭合路径写
minuteToTime结果(HHMM, 4位), 盘外分支写TimeUtils::getCurMin()(HHMMSS, 6位); 而读取端isInTradingTime(_time/100000)按9位格式解释。首次本地 闭合后_time变为HHMM(4位), /100000后为0被误判盘外而进入盘外分支; 此时
一条行情tick又将_time刷新回9位, 盘外分支内"curTime(6位) < _time(9位)" 恒成立, 交易日被错误滚动到次日; 此后行情tick因uDate < _date在入口被
全部丢弃, on_minute_end亦被节假日判定拦截, 引擎永久失联。

问题修复:
统一_time全链路为HHMMSSmmm格式: 本地闭合路径写thisMin * 100000;
盘外分支将getCurMin()结果乘1000对齐, 回调on_minute_end时以
_time / 100000还原为HHMM。跨日比较恢复为同格式的单调比较, 仅在真
午夜换日时成立, 盘中不再误入盘外分支。

验证:
实盘仿真环境(WT_DRY_RUN演练)部署后连续7分钟以上bar闭合与调度全部
正常, 策略决策与当日去重稳定; 修复前该场景必现在1~2分钟内永久静默。