### PR TITLE
fix: 信号/成交/平仓等诊断CSV浮点字段输出科学计数法且大数精度损失

### DIFF
--- a/src/WtBtCore/CtaMocker.cpp
+++ b/src/WtBtCore/CtaMocker.cpp
@@ -395,21 +395,21 @@ void CtaMocker::dump_outputs()
 
 void CtaMocker::log_signal(const char* stdCode, double target, double price, uint64_t gentime, const char* usertag /* = "" */)
 {
-	_sig_logs << stdCode << "," << target << "," << price << "," << gentime << "," << usertag << "\n";
+	_sig_logs << fmt::format("{},{},{},{},{}\n", stdCode, target, price, gentime, usertag);
 }
 
 void CtaMocker::log_trade(const char* stdCode, bool isLong, bool isOpen, uint64_t curTime, double price, double qty, const char* userTag, double fee, uint32_t barNo)
 {
-	_trade_logs << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE") 
-		<< "," << price << "," << qty << "," << userTag << "," << fee << "," << barNo << "\n";
+	_trade_logs << fmt::format("{},{},{},{},{},{},{},{:.2f},{}\n", stdCode, curTime,
+		(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, userTag, fee, barNo);
 }
 
-void CtaMocker::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double maxprofit, double maxloss, 
+void CtaMocker::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double maxprofit, double maxloss,
 	double totalprofit /* = 0 */, const char* enterTag /* = "" */, const char* exitTag /* = "" */, uint32_t openBarNo /* = 0 */, uint32_t closeBarNo /* = 0 */)
 {
-	_close_logs << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-		<< "," << closeTime << "," << closepx << "," << qty << "," << profit << "," << maxprofit << "," << maxloss << ","
-		<< totalprofit << "," << enterTag << "," << exitTag << "," << openBarNo << "," << closeBarNo << "\n";
+	_close_logs << fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{:.2f},{:.2f},{},{},{},{}\n", stdCode,
+		(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit, maxprofit, maxloss,
+		totalprofit, enterTag, exitTag, openBarNo, closeBarNo);
 }
 
 bool CtaMocker::init_cta_factory(WTSVariant* cfg)

--- a/src/WtBtCore/ExecMocker.cpp
+++ b/src/WtBtCore/ExecMocker.cpp
@@ -300,19 +300,9 @@ void ExecMocker::handle_order(uint32_t localid, const char* stdCode, bool isBuy,
 		if (_sig_px == DBL_MAX)
 			_sig_px = _last_tick->preclose();
 
-		_trade_logs << localid << ","
-			<< _sig_time << ","
-			<< ordTime << ","
-			<< (isBuy ? "B" : "S") << ","
-			<< _sig_px << ","
-			<< 0 << ","
-			<< price << ","
-			<< curTime << ","
-			<< price << ","
-			<< 0 << ","
-			<< curUnixTime - sigUnixTime << ","
-			<< curUnixTime - ordUnixTime << ","
-			<< "true" << std::endl;
+		_trade_logs << fmt::format("{},{},{},{},{},{},{},{},{},{},{},{},true\n", localid, _sig_time,
+			ordTime, (isBuy ? "B" : "S"), _sig_px, 0, price, curTime, price, 0,
+			curUnixTime - sigUnixTime, curUnixTime - ordUnixTime);
 
 		_undone -= leftover * (isBuy ? 1 : -1);
 		WTSLogger::info("{}, undone orders updated: {}", __FUNCTION__, _undone);
@@ -332,19 +322,9 @@ void ExecMocker::handle_trade(uint32_t localid, const char* stdCode, bool isBuy,
 	if (_sig_px == DBL_MAX)
 		_sig_px = _last_tick->preclose();
 
-	_trade_logs << localid << ","
-		<< _sig_time << ","
-		<< ordTime << ","
-		<< (isBuy?"B":"S") << ","
-		<< _sig_px << ","
-		<< fireprice << ","
-		<< price << ","
-		<< curTime << ","
-		<< price << ","
-		<< vol << ","
-		<< curUnixTime - sigUnixTime << ","
-		<< curUnixTime - ordUnixTime << ","
-		<< "false" << std::endl;
+	_trade_logs << fmt::format("{},{},{},{},{},{},{},{},{},{},{},{},false\n", localid, _sig_time,
+		ordTime, (isBuy ? "B" : "S"), _sig_px, fireprice, price, curTime, price, vol,
+		curUnixTime - sigUnixTime, curUnixTime - ordUnixTime);
 
 	_position += vol* (isBuy?1:-1);
 	_undone -= vol * (isBuy ? 1 : -1);

--- a/src/WtBtCore/HftMocker.cpp
+++ b/src/WtBtCore/HftMocker.cpp
@@ -773,8 +773,8 @@ bool HftMocker::procOrder(uint32_t localid)
 
 		double curPos = stra_get_position(ordInfo->_code);
 
-		_sig_logs << _replayer->get_date() << "." << _replayer->get_raw_time() << "." << _replayer->get_secs() << ","
-			<< (ordInfo->_isBuy ? "+" : "-") << curQty << "," << curPos << "," << curPx << std::endl;
+		_sig_logs << fmt::format("{}.{}.{},{}{},{},{}\n", _replayer->get_date(), _replayer->get_raw_time(),
+			_replayer->get_secs(), (ordInfo->_isBuy ? "+" : "-"), curQty, curPos, curPx);
 	}
 
 	//if(ordInfo->_left == 0)
@@ -1077,16 +1077,16 @@ void HftMocker::dump_outputs()
 
 void HftMocker::log_trade(const char* stdCode, bool isLong, bool isOpen, uint64_t curTime, double price, double qty, double fee, const char* userTag/* = ""*/)
 {
-	_trade_logs << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE")
-		<< "," << price << "," << qty << "," << fee << "," << userTag << "\n";
+	_trade_logs << fmt::format("{},{},{},{},{},{},{:.2f},{}\n", stdCode, curTime,
+		(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, fee, userTag);
 }
 
 void HftMocker::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double maxprofit, double maxloss,
 	double totalprofit /* = 0 */, const char* enterTag/* = ""*/, const char* exitTag/* = ""*/)
 {
-	_close_logs << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-		<< "," << closeTime << "," << closepx << "," << qty << "," << profit << "," << maxprofit << "," << maxloss << ","
-		<< totalprofit << "," << enterTag << "," << exitTag << "\n";
+	_close_logs << fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{:.2f},{:.2f},{},{}\n", stdCode,
+		(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit, maxprofit, maxloss,
+		totalprofit, enterTag, exitTag);
 }
 
 void HftMocker::do_set_position(const char* stdCode, double qty, double price /* = 0.0 */, const char* userTag /*= ""*/)

--- a/src/WtBtCore/SelMocker.cpp
+++ b/src/WtBtCore/SelMocker.cpp
@@ -214,20 +214,21 @@ void SelMocker::dump_outputs()
 
 void SelMocker::log_signal(const char* stdCode, double target, double price, uint64_t gentime, const char* usertag /* = "" */)
 {
-	_sig_logs << stdCode << "," << target << "," << price << "," << gentime << "," << usertag << "\n";
+	_sig_logs << fmt::format("{},{},{},{},{}\n", stdCode, target, price, gentime, usertag);
 }
 
 void SelMocker::log_trade(const char* stdCode, bool isLong, bool isOpen, uint64_t curTime, double price, double qty, const char* userTag, double fee)
 {
-	_trade_logs << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE") << "," << price << "," << qty << "," << userTag << "," << fee << "\n";
+	_trade_logs << fmt::format("{},{},{},{},{},{},{},{:.2f}\n", stdCode, curTime,
+		(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, userTag, fee);
 }
 
 void SelMocker::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double maxprofit, double maxloss,
 	double totalprofit /* = 0 */, const char* enterTag /* = "" */, const char* exitTag /* = "" */, uint32_t openBarNo/* = 0*/, uint32_t closeBarNo/* = 0*/)
 {
-	_close_logs << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-		<< "," << closeTime << "," << closepx << "," << qty << "," << profit << "," << maxprofit << "," << maxloss << ","
-		<< totalprofit << "," << enterTag << "," << exitTag << "," << openBarNo << "," << closeBarNo << "\n";
+	_close_logs << fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{:.2f},{:.2f},{},{},{},{}\n", stdCode,
+		(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit, maxprofit, maxloss,
+		totalprofit, enterTag, exitTag, openBarNo, closeBarNo);
 }
 
 bool SelMocker::init_sel_factory(WTSVariant* cfg)

--- a/src/WtBtCore/UftMocker.cpp
+++ b/src/WtBtCore/UftMocker.cpp
@@ -1140,16 +1140,16 @@ void UftMocker::dump_outputs()
 
 void UftMocker::log_trade(const char* stdCode, bool isLong, uint32_t offset, uint64_t curTime, double price, double qty, double fee)
 {
-	_trade_logs << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << OFFSET_NAMES[offset]
-		<< "," << price << "," << qty << "," << fee  << "\n";
+	_trade_logs << fmt::format("{},{},{},{},{},{},{:.2f}\n", stdCode, curTime,
+		(isLong ? "LONG" : "SHORT"), OFFSET_NAMES[offset], price, qty, fee);
 }
 
 void UftMocker::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double maxprofit, double maxloss,
 	double totalprofit /* = 0 */)
 {
-	_close_logs << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-		<< "," << closeTime << "," << closepx << "," << qty << "," << profit << "," << maxprofit << "," << maxloss << ","
-		<< totalprofit << "\n";
+	_close_logs << fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{:.2f},{:.2f}\n", stdCode,
+		(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit, maxprofit, maxloss,
+		totalprofit);
 }
 
 void UftMocker::update_position(const char* stdCode, bool isLong, uint32_t offset, double qty, double price /* = 0.0 */)

--- a/src/WtCore/CtaStraBaseCtx.cpp
+++ b/src/WtCore/CtaStraBaseCtx.cpp
@@ -191,9 +191,7 @@ void CtaStraBaseCtx::log_signal(const char* stdCode, double target, double price
 {
 	if (_sig_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << target << "," << price << "," << gentime << "," << usertag << "\n";
-		_sig_logs->write_file(ss.str());
+		_sig_logs->write_file(fmt::format("{},{},{},{},{}\n", stdCode, target, price, gentime, usertag));
 	}
 }
 
@@ -201,24 +199,21 @@ void CtaStraBaseCtx::log_trade(const char* stdCode, bool isLong, bool isOpen, ui
 {
 	if (_trade_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE") << "," << price << "," << qty << "," << userTag << "," << fee << "," << barNo << "\n";
-		_trade_logs->write_file(ss.str());
+		_trade_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f},{}\n", stdCode, curTime,
+			(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, userTag, fee, barNo));
 	}
 
 	_engine->notify_trade(this->name(),stdCode, isLong, isOpen, curTime, price, userTag);
 }
 
-void CtaStraBaseCtx::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double totalprofit /* = 0 */, 
+void CtaStraBaseCtx::log_close(const char* stdCode, bool isLong, uint64_t openTime, double openpx, uint64_t closeTime, double closepx, double qty, double profit, double totalprofit /* = 0 */,
 	const char* enterTag /* = "" */, const char* exitTag /* = "" */, uint32_t openBarNo /* = 0 */, uint32_t closeBarNo /* = 0 */)
 {
 	if (_close_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-			<< "," << closeTime << "," << closepx << "," << qty << "," << profit << "," 
-			<< totalprofit << "," << enterTag << "," << exitTag << "," << openBarNo << "," << closeBarNo << "\n";
-		_close_logs->write_file(ss.str());
+		_close_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{},{},{},{}\n", stdCode,
+			(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit,
+			totalprofit, enterTag, exitTag, openBarNo, closeBarNo));
 	}
 }
 void CtaStraBaseCtx::save_userdata()
@@ -1987,9 +1982,7 @@ void CtaStraBaseCtx::add_chart_mark(double price, const char* icon, const char* 
 
 	if (_mark_logs)
 	{
-		std::stringstream ss;
-		ss << curTime << "," << price << "," << icon << "," << tag << std::endl;;
-		_mark_logs->write_file(ss.str());
+		_mark_logs->write_file(fmt::format("{},{},{},{}\n", curTime, price, icon, tag));
 	}
 
 	_engine->notify_chart_marker(curTime, _name.c_str(), price, icon, tag);
@@ -2060,9 +2053,7 @@ bool CtaStraBaseCtx::set_index_value(const char* idxName, const char* lineName, 
 
 	if (_idx_logs)
 	{
-		std::stringstream ss;
-		ss << curTime << "," << idxName << "," << lineName << "," << val << std::endl;;
-		_idx_logs->write_file(ss.str());
+		_idx_logs->write_file(fmt::format("{},{},{},{}\n", curTime, idxName, lineName, val));
 	}
 
 	_engine->notify_chart_index(curTime, _name.c_str(), idxName, lineName, val);

--- a/src/WtCore/HftStraBaseCtx.cpp
+++ b/src/WtCore/HftStraBaseCtx.cpp
@@ -970,10 +970,8 @@ void HftStraBaseCtx::log_trade(const char* stdCode, bool isLong, bool isOpen, ui
 {
 	if(_trade_logs && _data_agent)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE")
-			<< "," << price << "," << qty << "," << userTag << "," << fee << "\n";
-		_trade_logs->write_file(ss.str());
+		_trade_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f}\n", stdCode, curTime,
+			(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, userTag, fee));
 	}
 }
 
@@ -982,10 +980,8 @@ void HftStraBaseCtx::log_close(const char* stdCode, bool isLong, uint64_t openTi
 {
 	if (_close_logs && _data_agent)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-			<< "," << closeTime << "," << closepx << "," << qty << "," << profit << "," << maxprofit << "," << maxloss << ","
-			<< totalprofit << "," << enterTag << "," << exitTag << "\n";
-		_close_logs->write_file(ss.str());
+		_close_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{:.2f},{:.2f},{},{}\n", stdCode,
+			(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit, maxprofit, maxloss,
+			totalprofit, enterTag, exitTag));
 	}
 }

--- a/src/WtCore/SelStraBaseCtx.cpp
+++ b/src/WtCore/SelStraBaseCtx.cpp
@@ -143,9 +143,7 @@ void SelStraBaseCtx::log_signal(const char* stdCode, double target, double price
 {
 	if (_sig_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << target << "," << price << "," << gentime << "," << usertag << "\n";
-		_sig_logs->write_file(ss.str());
+		_sig_logs->write_file(fmt::format("{},{},{},{},{}\n", stdCode, target, price, gentime, usertag));
 	}
 }
 
@@ -153,9 +151,8 @@ void SelStraBaseCtx::log_trade(const char* stdCode, bool isLong, bool isOpen, ui
 {
 	if (_trade_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE") << "," << price << "," << qty << "," << userTag << "," << fee << "\n";
-		_trade_logs->write_file(ss.str());
+		_trade_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f}\n", stdCode, curTime,
+			(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, userTag, fee));
 	}
 }
 
@@ -164,11 +161,9 @@ void SelStraBaseCtx::log_close(const char* stdCode, bool isLong, uint64_t openTi
 {
 	if (_close_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-			<< "," << closeTime << "," << closepx << "," << qty << "," << profit << ","
-			<< totalprofit << "," << enterTag << "," << exitTag << "\n";
-		_trade_logs->write_file(ss.str());
+		_trade_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f},{},{}\n", stdCode,
+			(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit,
+			totalprofit, enterTag, exitTag));
 	}
 }
 

--- a/src/WtCore/WtEngine.cpp
+++ b/src/WtCore/WtEngine.cpp
@@ -1211,9 +1211,8 @@ void WtEngine::log_trade(const char* stdCode, bool isLong, bool isOpen, uint64_t
 {
 	if (_trade_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << curTime << "," << (isLong ? "LONG" : "SHORT") << "," << (isOpen ? "OPEN" : "CLOSE") << "," << price << "," << qty << "," << fee << "\n";
-		_trade_logs->write_file(ss.str());
+		_trade_logs->write_file(fmt::format("{},{},{},{},{},{},{:.2f}\n", stdCode, curTime,
+			(isLong ? "LONG" : "SHORT"), (isOpen ? "OPEN" : "CLOSE"), price, qty, fee));
 	}
 }
 
@@ -1221,10 +1220,7 @@ void WtEngine::log_close(const char* stdCode, bool isLong, uint64_t openTime, do
 {
 	if (_close_logs)
 	{
-		std::stringstream ss;
-		ss << stdCode << "," << (isLong ? "LONG" : "SHORT") << "," << openTime << "," << openpx
-			<< "," << closeTime << "," << closepx << "," << qty << "," << profit << ","
-			<< totalprofit << "\n";
-		_close_logs->write_file(ss.str());
+		_close_logs->write_file(fmt::format("{},{},{},{},{},{},{},{:.2f},{:.2f}\n", stdCode,
+			(isLong ? "LONG" : "SHORT"), openTime, openpx, closeTime, closepx, qty, profit, totalprofit));
 	}
 }


### PR DESCRIPTION
问题背景:
WtCore(WtPorter生产引擎)与WtBtCore(WtBtPorter回测引擎)中, 策略上下文与 Mocker的信号/成交/平仓/图表标记/指标线等诊断CSV的行内容, 一直用
std::stringstream的<<流式拼接生成. iostream对浮点的默认输出格式为
6位有效数字的%g风格, 同文件内已有的持仓(funds/positions)流水则使用
fmt::format, 两者格式不一致.

问题表现:
回测输出的signals.csv/trades.csv/closes.csv中, 大数值字段渲染为
科学计数法(如1693700 -> 1.6937e+06), 人读困难; 更严重的是超过6位
有效数字的数量字段被四舍五入(如134503900 -> 1.34504e+08, 凭空多出
100股), 导致CSV无法用于逐股精确对账.

问题原因:
std::stringstream的<<运算符对double采用std::defaultfloat(精度6, 指数>=5时转科学计数法), 而 positions.csv/funds.csv 使用的
fmt::format("{}") 是最短往返十进制表示, 既无科学计数法也无精度损失.

问题修复:
将全部诊断CSV行写入统一改为fmt::format, 与同文件/同库既有的
positions/funds流水惯例对齐:
- 数量/价格字段(target/qty/price等)使用{}, 最短往返表示, 精确无损;
- 金额字段(fee/profit/maxprofit等)使用{:.2f}, 与funds/positions一致. 涉及: WtCore的SelStraBaseCtx/CtaStraBaseCtx/HftStraBaseCtx/WtEngine, WtBtCore的SelMocker/CtaMocker/HftMocker/UftMocker/ExecMocker, 共约20处行写入. 字段名/字段顺序/触发条件均保持不变, 仅改格式化方式.

验证: 重新编译WtCore/WtBtCore/WtPorter/WtBtPorter并部署后, 以实际量化 策略回测验证(覆盖常规资金规模与数亿级持仓数量的场景)实测, signals.csv/
trades.csv/closes.csv全部输出普通十进制数, 三者数量字段逐股核对一致,
无科学计数法无精度损失.