### PR TITLE
fix: WtBtPorter入口路径参数未做UTF8转本地ANSI, 非ASCII路径下静默失效

### DIFF
--- a/src/WtBtPorter/WtBtPorter.cpp
+++ b/src/WtBtPorter/WtBtPorter.cpp
@@ -19,6 +19,10 @@
 
 #include "../Includes/WTSVersion.h"
 
+#ifdef _WIN32
+#include "../Share/charconv.hpp"
+#endif
+
 
 #ifdef _WIN32
 #ifdef _WIN64
@@ -83,6 +87,18 @@ void init_backtest(const char* logProfile, bool isFile, const char* outDir)
 	if (inited)
 		return;
 
+#ifdef _WIN32
+	//Python层传入的路径为UTF-8字节, 而Win下窄字符文件接口按ANSI编码解释,
+	//含非ASCII字符(如中文)的路径需先转为本地ANSI编码, 否则报文件不存在;
+	//与WtPorter的init_porter同规则
+	UTF8toChar log_conv(logProfile);
+	if (isFile)
+		logProfile = log_conv.c_str();
+
+	UTF8toChar out_conv(outDir);
+	outDir = out_conv.c_str();
+#endif
+
 	getRunner().init(logProfile, isFile, outDir);
 
 	inited = true;
@@ -98,7 +114,15 @@ void config_backtest(const char* cfgfile, bool isFile)
 	if (strlen(cfgfile) == 0)
 		getRunner().config("configbt.json", true);
 	else
+	{
+#ifdef _WIN32
+		//路径编码转换, 参见init_backtest注释; 内容模式下为配置文本, 不可转换
+		UTF8toChar cfg_conv(cfgfile);
+		if (isFile)
+			cfgfile = cfg_conv.c_str();
+#endif
 		getRunner().config(cfgfile, isFile);
+	}
 }
 
 void set_time_range(WtUInt64 stime, WtUInt64 etime)


### PR DESCRIPTION
【问题背景】
wtpy等Python桥接层经ctypes传入动态库的字符串参数为UTF-8字节编码,
而Windows下C++窄字符文件接口(StdFile::exists/std::ifstream等)按本地 ANSI代码页解释路径字节。WtBtPorter的init_backtest(logProfile, isFile, outDir)与config_backtest(cfgfile, isFile)直接接收这些路径参数, 用于 日志初始化、回测输出目录设置与回测配置加载。

【问题表现】
工程目录或传入路径含中文等非ASCII字符时, 显式传入绝对路径形式的日志
配置后回测无文件日志: WTSLogger::init先以StdFile::exists检查logProfile, UTF-8字节被按ANSI解释后指向不存在的文件, exists判定失败即静默返回,
日志退化为纯控制台且无任何报错; config_backtest以isFile=true传非ASCII 配置路径时同理加载失败。纯ASCII路径不受影响。

【问题原因】
文件存在性前置检查发生在任何配置加载器内部编码处理之前, 入口处未做
编码归一; Windows窄字符接口的ANSI解释与Python桥接层的UTF-8编码不匹配,
路径字节被错误转写后指向不存在的文件。

【问题修复】
init_backtest: logProfile(仅isFile时)与outDir经Share/charconv.hpp的 UTF8toChar转为本地ANSI(纯ASCII与非法UTF-8字节序列自动透传, 现有ASCII 路径行为不变); config_backtest: cfgfile仅isFile时同规则转换(内容模式 下为配置文本, 不可在此转换)。转换仅在_WIN32宏内编译, Linux窄字符接口
本身即UTF-8, 不参与编译。

【验证方式】
以实际运行的量化策略回测引擎验证: 含中文的工程目录下, 显式传入非ASCII
绝对路径的日志配置后文件日志正常生成, 回测全流程行为与ASCII路径场景
完全一致。