### PR TITLE
fix: 嵌入式DLL的Runner构造函数劫持宿主SIGINT并exit硬杀进程

### DIFF
--- a/src/WtBtPorter/WtBtRunner.cpp
+++ b/src/WtBtPorter/WtBtRunner.cpp
@@ -23,7 +23,6 @@
 #include "../WTSTools/WTSLogger.h"
 #include "../WTSUtils/WTSCfgLoader.h"
 #include "../Includes/WTSVariant.hpp"
-#include "../WTSUtils/SignalHook.hpp"
 
 #ifdef _MSC_VER
 #include "../Common/mdump.h"
@@ -87,9 +86,6 @@ WtBtRunner::WtBtRunner()
 	, _running(false)
 	, _async(false)
 {
-	install_signal_hooks([](const char* message) {
-		WTSLogger::error(message);
-	});
 }
 
 

--- a/src/WtDtServo/WtDtRunner.cpp
+++ b/src/WtDtServo/WtDtRunner.cpp
@@ -15,7 +15,6 @@
 #include "../Includes/WTSDataDef.hpp"
 #include "../Includes/WTSContractInfo.hpp"
 
-#include "../WTSUtils/SignalHook.hpp"
 #include "../WTSUtils/WTSCfgLoader.h"
 #include "../WTSTools/WTSLogger.h"
 
@@ -30,9 +29,6 @@ WtDtRunner::WtDtRunner()
 	: _data_store(NULL)
 	, _is_inited(false)
 {
-	install_signal_hooks([](const char* message) {
-		WTSLogger::error(message);
-	});
 }
 
 

--- a/src/WtExecMon/WtExecRunner.cpp
+++ b/src/WtExecMon/WtExecRunner.cpp
@@ -35,9 +35,6 @@ const char* getModuleName()
 
 WtExecRunner::WtExecRunner()
 {
-	install_signal_hooks([](const char* message) {
-		WTSLogger::error(message);
-	});
 }
 
 bool WtExecRunner::init(const char* logCfg /* = "logcfgexec.json" */, bool isFile /* = true */)


### PR DESCRIPTION
问题背景:
WTSUtils/SignalHook.hpp 提供的 install_signal_hooks 遍历全部信号执行 signal(s, handle_signal), 将 SIGINT/SIGBREAK/SIGTERM 等统一接管, 默认 处理为记录日志并 exit(signum)。该机制面向独立运行的控制台程序:
QuoteFactory/WtBtRunner/WtRunner 等 exe 均在自身 main 或运行函数中安装, 进程归程序自身所有, 行为正确。但 WtDtServo(WtDtRunner)、
WtBtPorter(WtBtRunner)、WtExecMon(WtExecRunner) 三个工程均为纯动态库 (DynamicLibrary, 无独立 exe 消费者), 其 Runner 构造函数中也调用了
install_signal_hooks, 且只传日志回调、未传 ExitHandler。

问题表现:
宿主程序(如 Python 经 wtpy)加载上述 DLL 并触发 Runner 构造后, 宿主
此前注册的 SIGINT 处理器被覆盖。此后 Ctrl+C 不再进入宿主的键盘中断
流程, 而是走原生 handle_signal: 输出 "app interrupted" 后执行
exit(SIGINT) 即 exit(2), 整个宿主进程被立即硬杀, 宿主的资源清理与
异常处理逻辑全部跳过。以 Python 宿主实测: 构造触发后发送 Ctrl+C,
进程约 20ms 内以退出码 2 终止, KeyboardInterrupt 与 atexit 均未执行。

问题原因:
信号处置权应归属进程所有者: 独立程序为自身 main, 嵌入场景为宿主。
三个 DLL 的 Runner 构造函数无条件安装信号钩子, 侵占了宿主的信号
处置权; 且未传 ExitHandler 时 handle_signal 直接 exit(signum), 库代码调用 exit 终止整个宿主进程。

问题修复:
删除三个 DLL Runner 构造函数中的 install_signal_hooks 调用, 信号 处置权归还宿主。WtDtServo/WtBtPorter 中不再使用的 SignalHook.hpp include 一并移除; WtExecMon 因异常路径仍在使用 print_stack_trace, include 保留。独立 exe 在自身 main/运行函数中的钩子安装不受影响;
WtDtPorter/WtRtRunner 中带优雅退出标志的协作式安装亦不涉及。

影响范围:
仅影响将上述三个 DLL 嵌入外部宿主的场景: 宿主重新获得 Ctrl+C 控制
权, 可自行决定信号处理方式。三个 DLL 无独立 exe 形态, 独立程序行为
不变;  DLL 内部对 SIGSEGV 等崩溃信号的钩子如宿主需要可自行安装。

验证方式:
VS2017 Release x64 编译通过并部署; 以 Python 宿主分别加载 WtDtServo (读取K线完成初始化)与 WtBtPorter(构造回测引擎)后发送 Ctrl+C: 修复前
进程以退出码 2 被原生路径硬杀、KeyboardInterrupt 不触发; 修复后宿主
正常捕获 KeyboardInterrupt, atexit 清理完整执行, 退出码 0。

兼容性说明:
嵌入宿主若此前依赖"Ctrl+C 由 DLL 记日志并退出进程"的行为, 需在宿主
侧自行处理 SIGINT(嵌入场景本应由宿主决定); 独立 exe 无任何变化。