### PR TITLE
fix: 回测定时任务回放的会话事件错位(非交易日幽灵会话/结束日后多余会话)

### DIFF
--- a/src/WtBtCore/HisDataReplayer.cpp
+++ b/src/WtBtCore/HisDataReplayer.cpp
@@ -663,6 +663,31 @@ bool HisDataReplayer::prepare()
 	_cur_secs = 0;
 	_cur_tdate = _bd_mgr.calcTradingDate(DEFAULT_SESSIONID, _cur_date, _cur_time, true);
 
+	/*
+	 *	By xukanshan @ 2026.09.01
+	 *	定时任务回放模式下(_task非空), 若回测起始日为非交易日(周末/节假日, isHoliday已含周末判定),
+	 *	将回放起点顺延到首个交易日. 否则时钟会先在非交易日上空转一整个会话,
+	 *	触发一次无行情的幽灵 session begin/end, 且首个交易日顺延后标签与交易日历对齐
+	 */
+	if (_task != NULL && _bd_mgr.isHoliday(_task->_trdtpl, _cur_date, true))
+	{
+		uint32_t firstTDate = _bd_mgr.getNextTDate(_task->_trdtpl, _cur_date, 1, true);
+		const char* sid = strlen(_task->_session) > 0 ? _task->_session : DEFAULT_SESSIONID;
+		WTSSessionInfo* sInfo = _bd_mgr.getSession(sid);
+		if (sInfo != NULL)
+		{
+			uint64_t beginTime = _bd_mgr.getBoundaryTime(sInfo->id(), firstTDate, true, true);
+			_cur_date = (uint32_t)(beginTime / 10000);
+			_cur_time = (uint32_t)(beginTime % 10000);
+		}
+		else
+		{
+			_cur_date = firstTDate;
+		}
+		WTSLogger::info("Backtest start date {} is not a trading day, replaying starts from trading day {} instead", _begin_time, firstTDate);
+		_cur_tdate = firstTDate;
+	}
+
 	if (_notifier)
 		_notifier->notifyEvent("BT_START");
 
@@ -1076,10 +1101,15 @@ void HisDataReplayer::run_by_tasks(bool bNeedDump /* = false */)
 			uint64_t nextTime = (uint64_t)_cur_date * 10000 + _cur_time;
 			if (nextTime > _end_time)
 			{
+				/*
+				 *	By xukanshan @ 2026.09.01
+				 *	此处不再触发 handle_session_end: 日级及以上任务的触发路径与跳过路径
+				 *	都会内联闭合当日会话, 而 _cur_tdate 此刻已指向下一交易日(从未开启会话),
+				 *	原实现会多出一次无 begin 配对的孤儿 session end
+				 */
 				WTSLogger::log_raw(LL_INFO, "Backtesting with task frequency is done");
 				if (_listener)
 				{
-					_listener->handle_session_end(_cur_tdate);
 					_listener->handle_replay_done();
 					if (_notifier)
 						_notifier->notifyEvent("BT_END");
@@ -1175,6 +1205,24 @@ void HisDataReplayer::run_by_tasks(bool bNeedDump /* = false */)
 				}
 
 				_cur_time = sInfo->minuteToTime(mins);
+
+				/*
+				 *	By xukanshan @ 2026.09.01
+				 *	下一交易日已越过回测结束时间时, 不再开启新会话, 直接结束回放
+				 *	修复点: 原实现先触发 handle_session_begin 再在循环尾部做结束判断,
+				 *	导致结束日之后多出一次成对的 session begin/end 幽灵会话
+				 */
+				if ((uint64_t)_cur_date * 10000 + _cur_time > _end_time)
+				{
+					WTSLogger::log_raw(LL_INFO, "Backtesting with task frequency is done");
+					if (_listener)
+					{
+						_listener->handle_replay_done();
+						if (_notifier)
+							_notifier->notifyEvent("BT_END");
+					}
+					break;
+				}
 
 				if (_listener)
 					_listener->handle_session_begin(nextTDate);


### PR DESCRIPTION
问题背景:
WtBtCore 的 HisDataReplayer 按定时任务回放(run_by_tasks)时, 由时钟在每个 交易日的边界触发 handle_session_begin / handle_session_end, 首个交易日由 prepare() 依据 _begin_time 计算. 该事件序列是策略与外层观察者感知交易日
节奏的唯一依据, 应与交易日历严格一致.

问题表现:
- 回测起始日为周末或法定节假日时, 首个会话落在非交易日上, 空转一整个会话;
- 分钟任务下, 回测结束日的下一交易日多出一次成对的 session begin/end;
- 日级及以上任务结束时, 多出一次无 begin 配对的 session end.

问题原因:
- prepare() 直接以原始自然日作为首个交易日: WTSBaseDataMgr::calcTradingDate 对普通白盘会话只做周末顺延而不查节假日模板, 且当默认会话模板 TRADING 未在 basefiles.session 中定义时静默返回原始日期(sInfo == NULL 短路), 非交易日的起始时钟未被顺延;
- 分钟任务分支换日时先触发 handle_session_begin(下一交易日), 之后才在循环 尾部做 nextTime > _end_time 的结束判断, 越界的下一交易日先开后关;
- 日级及以上任务分支的结束块对"已推进到但从未开启会话"的下一交易日触发 handle_session_end(触发路径与跳过路径均已内联闭合当日会话).

问题修复:
- prepare() 中定时任务模式下检测起始日为非交易日(isHoliday 已含周末判定) 时, 以任务自身的交易日历模板取首个交易日, 并按 getBoundaryTime 将时钟 对齐到该日会话边界, 再更新 _cur_tdate;
- 分钟任务分支在触发 handle_session_begin 之前先做越界判断, 越界则不再 开启新会话, 直接结束回放;
- 日级及以上任务分支结束时不再触发该孤儿 session end. 修复均针对事件错位的产生机制本身, 修复后各模式下 begin/end 严格交替配对,
且不存在交易日历之外的事件.

验证方式:
以扩展数据加载器不供数的最小回测驱动真实 WtBtPorter.dll, 仅观察会话事件
序列: 起始日为周末/节假日时, 修复前首会话落于非交易日且结束日后多一对
begin/end, 修复后不存在交易日历之外的事件; 跨法定节假日的整月回放, 会话
数与交易日历的交易日数完全一致; 日级任务与缺失 TRADING 会话模板的配置下
行为一致.

兼容性: 仅影响回测回放器的会话事件序列, 实盘引擎(WtCore)与数据模块不受
影响; 若有外部逻辑依赖越界的幽灵会话事件, 将少收到一对无害的空事件.